### PR TITLE
Run tests also after merging

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,8 +2,8 @@ name: Run Pytest on Pull Request
 
 on:
   pull_request:
-    branches:
-      - main
+  push:
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
Previously tests did not run after merging.

This lead to incompatible changes being merged right after one another.

By running tests on main we will notice breaks earlier.

Other options would be to require every PR to rebase on main before merging. This is known as requiring linear history and can be changed in the project settings.