### PR TITLE
Replace pytz with stdlib zoneinfo/timezone, Bump python to 3.9

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -20,7 +20,6 @@ The following is a list of licensors and other acknowledgements for third-party 
 - Flask, licensed under the BSD License, see https://flask.palletsprojects.com/
 - NumPy, licensed under the BSD License, see https://numpy.org/
 - Requests, licensed under the Apache License 2.0, see https://requests.readthedocs.io/
-- pytz, licensed under the MIT License, see https://pythonhosted.org/pytz/
 - matplotlib, licensed under the matplotlib License (a variant of the Python Software Foundation License), see https://matplotlib.org/
 - DEAP, licensed under the GNU Lesser General Public License v3.0, see https://deap.readthedocs.io/
 - SciPy, licensed under the BSD License, see https://scipy.org/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 description = "This project provides a comprehensive solution for simulating and optimizing an energy system based on renewable energy sources. With a focus on photovoltaic (PV) systems, battery storage (batteries), load management (consumer requirements), heat pumps, electric vehicles, and consideration of electricity price data, this system enables forecasting and optimization of energy flow and costs over a specified period."
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",

--- a/src/akkudoktoreos/class_sommerzeit.py
+++ b/src/akkudoktoreos/class_sommerzeit.py
@@ -1,21 +1,18 @@
 import datetime
+import zoneinfo
 
-import pytz
 
-
-def ist_dst_wechsel(tag, timezone="Europe/Berlin"):
+def ist_dst_wechsel(tag: datetime.datetime, timezone="Europe/Berlin") -> bool:
     """Checks if Daylight Saving Time (DST) starts or ends on a given day."""
-    tz = pytz.timezone(timezone)
+    tz = zoneinfo.ZoneInfo(timezone)
     # Get the current day and the next day
     current_day = datetime.datetime(tag.year, tag.month, tag.day)
     next_day = current_day + datetime.timedelta(days=1)
 
-    # Localize the days in the given timezone
-    current_day_localized = tz.localize(current_day, is_dst=None)
-    next_day_localized = tz.localize(next_day, is_dst=None)
-
     # Check if the UTC offsets are different (indicating a DST change)
-    dst_change = current_day_localized.dst() != next_day_localized.dst()
+    dst_change = (
+        current_day.replace(tzinfo=tz).dst() != next_day.replace(tzinfo=tz).dst()
+    )
 
     return dst_change
 

--- a/src/akkudoktoreos/class_strompreis.py
+++ b/src/akkudoktoreos/class_strompreis.py
@@ -1,19 +1,11 @@
 import hashlib
 import json
 import os
-from datetime import datetime, timedelta
+import zoneinfo
+from datetime import datetime, timedelta, timezone
 
 import numpy as np
-import pytz
 import requests
-
-# Example: Converting a UTC timestamp to local time
-utc_time = datetime.strptime("2024-03-28T01:00:00.000Z", "%Y-%m-%dT%H:%M:%S.%fZ")
-utc_time = utc_time.replace(tzinfo=pytz.utc)
-
-# Replace 'Europe/Berlin' with your own timezone
-local_time = utc_time.astimezone(pytz.timezone("Europe/Berlin"))
-print(local_time)
 
 
 def repeat_to_shape(array, target_shape):
@@ -116,13 +108,13 @@ class HourlyElectricityPriceForecast:
         print(start_date_str)
         print(end_date_str)
         start_date_utc = datetime.strptime(start_date_str, "%Y-%m-%d").replace(
-            tzinfo=pytz.utc
+            tzinfo=timezone.utc
         )
         end_date_utc = datetime.strptime(end_date_str, "%Y-%m-%d").replace(
-            tzinfo=pytz.utc
+            tzinfo=timezone.utc
         )
-        start_date = start_date_utc.astimezone(pytz.timezone("Europe/Berlin"))
-        end_date = end_date_utc.astimezone(pytz.timezone("Europe/Berlin"))
+        start_date = start_date_utc.astimezone(zoneinfo.ZoneInfo("Europe/Berlin"))
+        end_date = end_date_utc.astimezone(zoneinfo.ZoneInfo("Europe/Berlin"))
 
         price_list = []
 


### PR DESCRIPTION
 * Timezone support comes with the standard lib since 3.9

Remove unlisted dependency pytz. If we want to keep it (comes as transitive dep atm), then we should put it into requirements.txt.