### PR TITLE
to_dict renamed

### DIFF
--- a/src/akkudoktoreos/class_akku.py
+++ b/src/akkudoktoreos/class_akku.py
@@ -35,7 +35,7 @@ class PVAkku:
         self.min_soc_wh = (self.min_soc_prozent / 100) * self.kapazitaet_wh
         self.max_soc_wh = (self.max_soc_prozent / 100) * self.kapazitaet_wh
 
-    def to_dict(self):
+    def return_dict(self):
         return {
             "kapazitaet_wh": self.kapazitaet_wh,
             "start_soc_prozent": self.start_soc_prozent,

--- a/src/akkudoktoreos/class_optimize.py
+++ b/src/akkudoktoreos/class_optimize.py
@@ -364,7 +364,7 @@ class optimization_problem:
             "discharge_hours_bin": discharge_hours_bin,
             "eautocharge_hours_float": eautocharge_hours_float,
             "result": o,
-            "eauto_obj": ems.eauto.to_dict(),
+            "eauto_obj": ems.eauto.return_dict(),
             "start_solution": start_solution,
             "spuelstart": spuelstart_int,
             "simulation_data": o,


### PR DESCRIPTION
Renamed the to_dict() function to return_dict() to avoid conflict with Pandas' to_dict() method and to prevent confusion with similarly named functions like to_list().