### PR TITLE
set min_soc_prozent 0 by default

### DIFF
--- a/src/akkudoktoreosserver/flask_server.py
+++ b/src/akkudoktoreosserver/flask_server.py
@@ -249,7 +249,7 @@ def flask_optimize():
 
         # Optional min SoC PV Battery
         if "min_soc_prozent" not in parameter:
-            parameter["min_soc_prozent"] = None
+            parameter["min_soc_prozent"] = 0
 
         # Perform optimization simulation
         result = opt_class.optimierung_ems(parameter=parameter, start_hour=datetime.now().hour)


### PR DESCRIPTION
fix for #183. The current default value of "Null" is not compatible with the class_akku. A default value of 0 is more reasonable.
We already set the value to 0 as default when we initialize the PVAkku class.