### PR TITLE
fix test_timezone_behaviour in windows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import platform
 import subprocess
 import sys
 import time
@@ -94,7 +95,9 @@ def other_timezone():
 
     # Change the timezone to another
     os.environ["TZ"] = other_tz
-    time.tzset()  # For Unix/Linux to apply the timezone change
+    # Apply tzset only on Unix-based systems
+    if platform.system() != "Windows":
+        time.tzset()
 
     yield os.environ["TZ"]  # Yield control back to the test case
 


### PR DESCRIPTION
The issue here is that time.tzset() is available on Unix-based systems (Linux, macOS) but is not supported on Windows. This function applies changes to the environment variable TZ for Unix systems, but there's no direct equivalent in Windows.

To make the test pass across platforms, we need a solution that avoids time.tzset() when running on Windows.