### PR TITLE
Mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,11 @@ repos:
         args: [--fix]
       # Run the formatter.
       - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.13.0'
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - "types-requests==2.32.0.20241016"
+          - "pandas-stubs==2.2.3.241009"
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Define the targets
-.PHONY: help venv pip install dist test test-full docker-run docker-build docs read-docs clean format run run-dev
+.PHONY: help venv pip install dist test test-full docker-run docker-build docs read-docs clean format mypy run run-dev
 
 # Default target
 all: help
@@ -11,6 +11,7 @@ help:
 	@echo "  pip          - Install dependencies from requirements.txt."
 	@echo "  pip-dev      - Install dependencies from requirements-dev.txt."
 	@echo "  format       - Format source code."
+	@echo "  mypy         - Run mypy."
 	@echo "  install      - Install EOS in editable form (development mode) into virtual environment."
 	@echo "  docker-run   - Run entire setup on docker"
 	@echo "  docker-build - Rebuild docker image"
@@ -99,6 +100,10 @@ test-full:
 # Target to format code.
 format:
 	.venv/bin/pre-commit run --all-files
+
+# Target to format code.
+mypy:
+	.venv/bin/mypy
 
 # Run entire setup on docker
 docker-run:

--- a/docs/akkudoktoreos/openapi.json
+++ b/docs/akkudoktoreos/openapi.json
@@ -363,17 +363,17 @@
           "hours": {
             "type": "integer",
             "title": "Hours",
-            "default": "Amount of hours the simulation is done for."
+            "description": "Amount of hours the simulation is done for."
           },
           "kapazitaet_wh": {
             "type": "integer",
             "title": "Kapazitaet Wh",
-            "default": "The capacity of the EV\u2019s battery in watt-hours."
+            "description": "The capacity of the EV\u2019s battery in watt-hours."
           },
           "lade_effizienz": {
             "type": "number",
             "title": "Lade Effizienz",
-            "default": "The charging efficiency as a float."
+            "description": "The charging efficiency as a float."
           },
           "max_ladeleistung_w": {
             "type": "integer",
@@ -396,6 +396,9 @@
           "charge_array",
           "discharge_array",
           "entlade_effizienz",
+          "hours",
+          "kapazitaet_wh",
+          "lade_effizienz",
           "max_ladeleistung_w",
           "soc_wh",
           "start_soc_prozent"
@@ -533,7 +536,14 @@
             }
           },
           "eauto": {
-            "$ref": "#/components/schemas/EAutoParameters"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EAutoParameters"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "dishwasher": {
             "anyOf": [
@@ -546,12 +556,19 @@
             ]
           },
           "temperature_forecast": {
-            "items": {
-              "type": "number"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Temperature Forecast",
-            "default": "An array of floats representing the temperature forecast in degrees Celsius for different time intervals."
+            "description": "An array of floats representing the temperature forecast in degrees Celsius for different time intervals."
           },
           "start_solution": {
             "anyOf": [
@@ -603,11 +620,33 @@
             "title": "Discharge Allowed",
             "description": "Array with discharge values (1 for discharge, 0 otherwise)."
           },
+          "eautocharge_hours_float": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Eautocharge Hours Float",
+            "description": "TBD"
+          },
           "result": {
             "$ref": "#/components/schemas/SimulationResult"
           },
           "eauto_obj": {
-            "$ref": "#/components/schemas/EAutoResult"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EAutoResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "start_solution": {
             "anyOf": [
@@ -642,6 +681,7 @@
           "ac_charge",
           "dc_charge",
           "discharge_allowed",
+          "eautocharge_hours_float",
           "result",
           "eauto_obj"
         ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,20 @@ convention = "google"
 minversion = "8.3.3"
 pythonpath = [ "src", ]
 testpaths = [ "tests", ]
+
+[tool.mypy]
+files = ["src", "tests"]
+exclude = "class_soc_calc\\.py$"
+check_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = "sklearn.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "deap.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "xprocess.*"
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,11 @@ testpaths = [ "tests", ]
 files = ["src", "tests"]
 exclude = "class_soc_calc\\.py$"
 check_untyped_defs = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = "akkudoktoreos.*"
+disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = "sklearn.*"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,6 @@ pytest==8.3.3
 pytest-cov==6.0.0
 pytest-xprocess==1.0.2
 pre-commit
+mypy==1.13.0
+types-requests==2.32.0.20241016
+pandas-stubs==2.2.3.241009

--- a/single_test_optimization.py
+++ b/single_test_optimization.py
@@ -7,11 +7,8 @@ import numpy as np
 from akkudoktoreos.config import get_working_dir, load_config
 from akkudoktoreos.optimization.genetic import (
     OptimizationParameters,
-    OptimizeResponse,
     optimization_problem,
 )
-from akkudoktoreos.utils import NumpyEncoder
-from akkudoktoreos.visualize import visualisiere_ergebnisse
 
 start_hour = 0
 
@@ -299,30 +296,4 @@ elapsed_time = end_time - start_time
 print(f"Elapsed time: {elapsed_time:.4f} seconds")
 
 
-ac_charge, dc_charge, discharge = (
-    ergebnis["ac_charge"],
-    ergebnis["dc_charge"],
-    ergebnis["discharge_allowed"],
-)
-
-visualisiere_ergebnisse(
-    parameters.ems.gesamtlast,
-    parameters.ems.pv_prognose_wh,
-    parameters.ems.strompreis_euro_pro_wh,
-    ergebnis["result"],
-    ac_charge,
-    dc_charge,
-    discharge,
-    parameters.temperature_forecast,
-    start_hour,
-    einspeiseverguetung_euro_pro_wh=np.full(
-        config.eos.feed_in_tariff_eur_per_wh, parameters.ems.einspeiseverguetung_euro_pro_wh
-    ),
-    config=config,
-)
-
-
-json_data = NumpyEncoder.dumps(ergebnis)
-print(json_data)
-
-OptimizeResponse(**ergebnis)
+print(ergebnis.model_dump())

--- a/src/akkudoktoreos/class_home_appliance.py
+++ b/src/akkudoktoreos/class_home_appliance.py
@@ -14,7 +14,7 @@ class HomeApplianceParameters(BaseModel):
 
 
 class HomeAppliance:
-    def __init__(self, parameters: HomeApplianceParameters, hours=None):
+    def __init__(self, parameters: HomeApplianceParameters, hours: int):
         self.hours = hours  # Total duration for which the planning is done
         self.consumption_wh = (
             parameters.consumption_wh
@@ -22,7 +22,7 @@ class HomeAppliance:
         self.duration_h = parameters.duration_h  # Duration of use in hours
         self.load_curve = np.zeros(self.hours)  # Initialize the load curve with zeros
 
-    def set_starting_time(self, start_hour, global_start_hour=0):
+    def set_starting_time(self, start_hour: int, global_start_hour: int = 0) -> None:
         """Sets the start time of the device and generates the corresponding load curve.
 
         :param start_hour: The hour at which the device should start.
@@ -40,15 +40,15 @@ class HomeAppliance:
         # Set the power for the duration of use in the load curve array
         self.load_curve[start_hour : start_hour + self.duration_h] = power_per_hour
 
-    def reset(self):
+    def reset(self) -> None:
         """Resets the load curve."""
         self.load_curve = np.zeros(self.hours)
 
-    def get_load_curve(self):
+    def get_load_curve(self) -> np.ndarray:
         """Returns the current load curve."""
         return self.load_curve
 
-    def get_load_for_hour(self, hour):
+    def get_load_for_hour(self, hour: int) -> float:
         """Returns the load for a specific hour.
 
         :param hour: The hour for which the load is queried.
@@ -59,6 +59,6 @@ class HomeAppliance:
 
         return self.load_curve[hour]
 
-    def get_latest_starting_point(self):
+    def get_latest_starting_point(self) -> int:
         """Returns the latest possible start time at which the device can still run completely."""
         return self.hours - self.duration_h

--- a/src/akkudoktoreos/config.py
+++ b/src/akkudoktoreos/config.py
@@ -13,7 +13,7 @@ Key features:
 import json
 import os
 import shutil
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any, Optional
 
@@ -273,9 +273,7 @@ def get_working_dir() -> Path:
     return working_dir
 
 
-def get_start_enddate(
-    prediction_hours: int, startdate: Optional[datetime] = None
-) -> tuple[str, str]:
+def get_start_enddate(prediction_hours: int, startdate: Optional[date] = None) -> tuple[str, str]:
     """Calculate the start and end dates based on the given prediction hours and optional start date.
 
     Args:

--- a/src/akkudoktoreos/devices/generic.py
+++ b/src/akkudoktoreos/devices/generic.py
@@ -22,7 +22,7 @@ class HomeAppliance:
         self.duration_h = parameters.duration_h  # Duration of use in hours
         self.load_curve = np.zeros(self.hours)  # Initialize the load curve with zeros
 
-    def set_starting_time(self, start_hour, global_start_hour=0):
+    def set_starting_time(self, start_hour: int, global_start_hour: int = 0):
         """Sets the start time of the device and generates the corresponding load curve.
 
         :param start_hour: The hour at which the device should start.

--- a/src/akkudoktoreos/devices/generic.py
+++ b/src/akkudoktoreos/devices/generic.py
@@ -14,7 +14,7 @@ class HomeApplianceParameters(BaseModel):
 
 
 class HomeAppliance:
-    def __init__(self, parameters: HomeApplianceParameters, hours=None):
+    def __init__(self, parameters: HomeApplianceParameters, hours: int = 24):
         self.hours = hours  # Total duration for which the planning is done
         self.consumption_wh = (
             parameters.consumption_wh
@@ -22,7 +22,7 @@ class HomeAppliance:
         self.duration_h = parameters.duration_h  # Duration of use in hours
         self.load_curve = np.zeros(self.hours)  # Initialize the load curve with zeros
 
-    def set_starting_time(self, start_hour: int, global_start_hour: int = 0):
+    def set_starting_time(self, start_hour: int, global_start_hour: int = 0) -> None:
         """Sets the start time of the device and generates the corresponding load curve.
 
         :param start_hour: The hour at which the device should start.
@@ -40,15 +40,15 @@ class HomeAppliance:
         # Set the power for the duration of use in the load curve array
         self.load_curve[start_hour : start_hour + self.duration_h] = power_per_hour
 
-    def reset(self):
+    def reset(self) -> None:
         """Resets the load curve."""
         self.load_curve = np.zeros(self.hours)
 
-    def get_load_curve(self):
+    def get_load_curve(self) -> np.ndarray:
         """Returns the current load curve."""
         return self.load_curve
 
-    def get_load_for_hour(self, hour):
+    def get_load_for_hour(self, hour: int) -> float:
         """Returns the load for a specific hour.
 
         :param hour: The hour for which the load is queried.
@@ -59,6 +59,6 @@ class HomeAppliance:
 
         return self.load_curve[hour]
 
-    def get_latest_starting_point(self):
+    def get_latest_starting_point(self) -> int:
         """Returns the latest possible start time at which the device can still run completely."""
         return self.hours - self.duration_h

--- a/src/akkudoktoreos/devices/heatpump.py
+++ b/src/akkudoktoreos/devices/heatpump.py
@@ -18,7 +18,7 @@ class Heatpump:
     COP_COEFFICIENT = 0.1
     """COP increase per degree"""
 
-    def __init__(self, max_heat_output, prediction_hours):
+    def __init__(self, max_heat_output: int, prediction_hours: int):
         self.max_heat_output = max_heat_output
         self.prediction_hours = prediction_hours
         self.log = logging.getLogger(__name__)

--- a/src/akkudoktoreos/devices/inverter.py
+++ b/src/akkudoktoreos/devices/inverter.py
@@ -14,9 +14,11 @@ class Wechselrichter:
         )
         self.akku = akku  # Connection to a battery object
 
-    def energie_verarbeiten(self, erzeugung, verbrauch, hour):
-        verluste = 0  # Losses during processing
-        netzeinspeisung = 0  # Grid feed-in
+    def energie_verarbeiten(
+        self, erzeugung: float, verbrauch: float, hour: int
+    ) -> tuple[float, float, float, float]:
+        verluste = 0.0  # Losses during processing
+        netzeinspeisung = 0.0  # Grid feed-in
         netzbezug = 0.0  # Grid draw
         eigenverbrauch = 0.0  # Self-consumption
 

--- a/src/akkudoktoreos/devices/inverter.py
+++ b/src/akkudoktoreos/devices/inverter.py
@@ -4,7 +4,7 @@ from akkudoktoreos.devices.battery import PVAkku
 
 
 class WechselrichterParameters(BaseModel):
-    max_leistung_wh: float = Field(10000, gt=0)
+    max_leistung_wh: float = Field(default=10000, gt=0)
 
 
 class Wechselrichter:

--- a/src/akkudoktoreos/optimization/genetic.py
+++ b/src/akkudoktoreos/optimization/genetic.py
@@ -166,7 +166,7 @@ class optimization_problem:
         return ac_charge, dc_charge, discharge
 
     # Custom mutation function that applies type-specific mutations
-    def mutate(self, individual):
+    def mutate(self, individual: list[int]) -> tuple[list[int]]:
         """Custom mutation function for the individual.
 
         This function mutates different parts of the individual:
@@ -232,7 +232,7 @@ class optimization_problem:
         return (individual,)
 
     # Method to create an individual based on the conditions
-    def create_individual(self):
+    def create_individual(self) -> list[int]:
         # Start with discharge states for the individual
         individual_components = [
             self.toolbox.attr_discharge_state() for _ in range(self.prediction_hours)
@@ -437,7 +437,7 @@ class optimization_problem:
             print("Start optimize:", start_solution)
 
         # Insert the start solution into the population if provided
-        if start_solution not in [None, -1]:
+        if start_solution is not None:
             for _ in range(3):
                 population.insert(0, creator.Individual(start_solution))
 
@@ -455,7 +455,7 @@ class optimization_problem:
             verbose=self.verbose,
         )
 
-        member: dict[str, list] = {"bilanz": [], "verluste": [], "nebenbedingung": []}
+        member: dict[str, list[float]] = {"bilanz": [], "verluste": [], "nebenbedingung": []}
         for ind in population:
             if hasattr(ind, "extra_data"):
                 extra_value1, extra_value2, extra_value3 = ind.extra_data

--- a/src/akkudoktoreos/prediction/load_container.py
+++ b/src/akkudoktoreos/prediction/load_container.py
@@ -2,11 +2,13 @@ import numpy as np
 
 
 class Gesamtlast:
-    def __init__(self, prediction_hours=24):
-        self.lasten = {}  # Contains names and load arrays for different sources
+    def __init__(self, prediction_hours: int = 24):
+        self.lasten: dict[
+            str, np.ndarray
+        ] = {}  # Contains names and load arrays for different sources
         self.prediction_hours = prediction_hours
 
-    def hinzufuegen(self, name, last_array):
+    def hinzufuegen(self, name: str, last_array: np.ndarray) -> None:
         """Adds an array of loads for a specific source.
 
         :param name: Name of the load source (e.g., "Household", "Heat Pump")
@@ -16,13 +18,13 @@ class Gesamtlast:
             raise ValueError(f"Total load inconsistent lengths in arrays: {name} {len(last_array)}")
         self.lasten[name] = last_array
 
-    def gesamtlast_berechnen(self):
+    def gesamtlast_berechnen(self) -> np.ndarray:
         """Calculates the total load for each hour and returns an array of total loads.
 
         :return: Array of total loads, where each entry corresponds to an hour
         """
         if not self.lasten:
-            return []
+            return np.ndarray(0)
 
         # Assumption: All load arrays have the same length
         stunden = len(next(iter(self.lasten.values())))

--- a/src/akkudoktoreos/prediction/load_corrector.py
+++ b/src/akkudoktoreos/prediction/load_corrector.py
@@ -1,28 +1,30 @@
+from datetime import datetime
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from sklearn.metrics import mean_squared_error, r2_score
 
+from akkudoktoreos.prediction.load_forecast import LoadForecast
+
 
 class LoadPredictionAdjuster:
-    def __init__(self, measured_data, predicted_data, load_forecast):
+    def __init__(
+        self, measured_data: pd.DataFrame, predicted_data: pd.DataFrame, load_forecast: LoadForecast
+    ):
         self.measured_data = measured_data
         self.predicted_data = predicted_data
         self.load_forecast = load_forecast
         self.merged_data = self._merge_data()
-        self.train_data = None
-        self.test_data = None
-        self.weekday_diff = None
-        self.weekend_diff = None
 
-    def _remove_outliers(self, data, threshold=2):
+    def _remove_outliers(self, data: pd.DataFrame, threshold=2) -> pd.DataFrame:
         # Calculate the Z-Score of the 'Last' data
         data["Z-Score"] = np.abs((data["Last"] - data["Last"].mean()) / data["Last"].std())
         # Filter the data based on the threshold
         filtered_data = data[data["Z-Score"] < threshold]
         return filtered_data.drop(columns=["Z-Score"])
 
-    def _merge_data(self):
+    def _merge_data(self) -> pd.DataFrame:
         # Convert the time column in both DataFrames to datetime
         self.predicted_data["time"] = pd.to_datetime(self.predicted_data["time"])
         self.measured_data["time"] = pd.to_datetime(self.measured_data["time"])
@@ -79,7 +81,7 @@ class LoadPredictionAdjuster:
             weekends_train_data.groupby("Hour").apply(self._weighted_mean_diff).dropna()
         )
 
-    def _weighted_mean_diff(self, data):
+    def _weighted_mean_diff(self, data: pd.DataFrame) -> float:
         train_end_date = self.train_data["time"].max()
         weights = 1 / (train_end_date - data["time"]).dt.days.replace(0, np.nan)
         weighted_mean = (data["Difference"] * weights).sum() / weights.sum()
@@ -89,7 +91,7 @@ class LoadPredictionAdjuster:
         self.train_data["Adjusted Pred"] = self.train_data.apply(self._adjust_row, axis=1)
         self.test_data["Adjusted Pred"] = self.test_data.apply(self._adjust_row, axis=1)
 
-    def _adjust_row(self, row):
+    def _adjust_row(self, row: pd.Series) -> pd.Series:
         if row["DayOfWeek"] < 5:
             return row["Last Pred"] + self.weekday_diff.get(row["Hour"], 0)
         else:
@@ -99,7 +101,7 @@ class LoadPredictionAdjuster:
         self._plot_data(self.train_data, "Training")
         self._plot_data(self.test_data, "Testing")
 
-    def _plot_data(self, data, data_type):
+    def _plot_data(self, data: pd.DataFrame, data_type: str):
         plt.figure(figsize=(14, 7))
         plt.plot(data["time"], data["Last"], label=f"Actual Last - {data_type}", color="blue")
         plt.plot(
@@ -129,7 +131,7 @@ class LoadPredictionAdjuster:
         print(f"Mean Squared Error: {mse}")
         print(f"R-squared: {r2}")
 
-    def predict_next_hours(self, hours_ahead):
+    def predict_next_hours(self, hours_ahead: int) -> pd.DataFrame:
         last_date = self.merged_data["time"].max()
         future_dates = [last_date + pd.Timedelta(hours=i) for i in range(1, hours_ahead + 1)]
         future_df = pd.DataFrame({"time": future_dates})
@@ -139,7 +141,7 @@ class LoadPredictionAdjuster:
         future_df["Adjusted Pred"] = future_df.apply(self._adjust_row, axis=1)
         return future_df
 
-    def _forecast_next_hours(self, timestamp):
+    def _forecast_next_hours(self, timestamp: datetime) -> float:
         date_str = timestamp.strftime("%Y-%m-%d")
         hour = timestamp.hour
         daily_forecast = self.load_forecast.get_daily_stats(date_str)

--- a/src/akkudoktoreos/prediction/load_corrector.py
+++ b/src/akkudoktoreos/prediction/load_corrector.py
@@ -17,7 +17,7 @@ class LoadPredictionAdjuster:
         self.load_forecast = load_forecast
         self.merged_data = self._merge_data()
 
-    def _remove_outliers(self, data: pd.DataFrame, threshold=2) -> pd.DataFrame:
+    def _remove_outliers(self, data: pd.DataFrame, threshold: int = 2) -> pd.DataFrame:
         # Calculate the Z-Score of the 'Last' data
         data["Z-Score"] = np.abs((data["Last"] - data["Last"].mean()) / data["Last"].std())
         # Filter the data based on the threshold
@@ -49,7 +49,9 @@ class LoadPredictionAdjuster:
         merged_data["DayOfWeek"] = merged_data["time"].dt.dayofweek
         return merged_data
 
-    def calculate_weighted_mean(self, train_period_weeks=9, test_period_weeks=1):
+    def calculate_weighted_mean(
+        self, train_period_weeks: int = 9, test_period_weeks: int = 1
+    ) -> None:
         self.merged_data = self._remove_outliers(self.merged_data)
         train_end_date = self.merged_data["time"].max() - pd.Timedelta(weeks=test_period_weeks)
         train_start_date = train_end_date - pd.Timedelta(weeks=train_period_weeks)
@@ -87,7 +89,7 @@ class LoadPredictionAdjuster:
         weighted_mean = (data["Difference"] * weights).sum() / weights.sum()
         return weighted_mean
 
-    def adjust_predictions(self):
+    def adjust_predictions(self) -> None:
         self.train_data["Adjusted Pred"] = self.train_data.apply(self._adjust_row, axis=1)
         self.test_data["Adjusted Pred"] = self.test_data.apply(self._adjust_row, axis=1)
 
@@ -97,11 +99,11 @@ class LoadPredictionAdjuster:
         else:
             return row["Last Pred"] + self.weekend_diff.get(row["Hour"], 0)
 
-    def plot_results(self):
+    def plot_results(self) -> None:
         self._plot_data(self.train_data, "Training")
         self._plot_data(self.test_data, "Testing")
 
-    def _plot_data(self, data: pd.DataFrame, data_type: str):
+    def _plot_data(self, data: pd.DataFrame, data_type: str) -> None:
         plt.figure(figsize=(14, 7))
         plt.plot(data["time"], data["Last"], label=f"Actual Last - {data_type}", color="blue")
         plt.plot(
@@ -125,7 +127,7 @@ class LoadPredictionAdjuster:
         plt.grid(True)
         plt.show()
 
-    def evaluate_model(self):
+    def evaluate_model(self) -> None:
         mse = mean_squared_error(self.test_data["Last"], self.test_data["Adjusted Pred"])
         r2 = r2_score(self.test_data["Last"], self.test_data["Adjusted Pred"])
         print(f"Mean Squared Error: {mse}")

--- a/src/akkudoktoreos/prediction/load_forecast.py
+++ b/src/akkudoktoreos/prediction/load_forecast.py
@@ -12,7 +12,7 @@ class LoadForecast:
         self.year_energy = year_energy
         self.load_data()
 
-    def get_daily_stats(self, date_str: str):
+    def get_daily_stats(self, date_str: str) -> np.ndarray:
         """Returns the 24-hour profile with mean and standard deviation for a given date.
 
         :param date_str: Date as a string in the format "YYYY-MM-DD"
@@ -28,7 +28,7 @@ class LoadForecast:
         daily_stats = self.data_year_energy[day_of_year - 1]  # -1 because indexing starts at 0
         return daily_stats
 
-    def get_hourly_stats(self, date_str: str, hour: int):
+    def get_hourly_stats(self, date_str: str, hour: int) -> np.ndarray:
         """Returns the mean and standard deviation for a specific hour of a given date.
 
         :param date_str: Date as a string in the format "YYYY-MM-DD"
@@ -46,7 +46,7 @@ class LoadForecast:
 
         return hourly_stats
 
-    def get_stats_for_date_range(self, start_date_str: str, end_date_str: str):
+    def get_stats_for_date_range(self, start_date_str: str, end_date_str: str) -> np.ndarray:
         """Returns the means and standard deviations for a date range.
 
         :param start_date_str: Start date as a string in the format "YYYY-MM-DD"
@@ -68,7 +68,7 @@ class LoadForecast:
         stats_for_range = stats_for_range.reshape(stats_for_range.shape[0], -1)
         return stats_for_range
 
-    def load_data(self):
+    def load_data(self) -> None:
         """Loads data from the specified file."""
         try:
             data = np.load(self.filepath)
@@ -80,7 +80,7 @@ class LoadForecast:
         except Exception as e:
             print(f"An error occurred while loading data: {e}")
 
-    def get_price_data(self):
+    def get_price_data(self) -> None:
         """Returns price data (currently not implemented)."""
         raise NotImplementedError
         # return self.price_data

--- a/src/akkudoktoreos/prediction/load_forecast.py
+++ b/src/akkudoktoreos/prediction/load_forecast.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 
 import numpy as np
 
@@ -6,14 +7,12 @@ import numpy as np
 
 
 class LoadForecast:
-    def __init__(self, filepath=None, year_energy=None):
+    def __init__(self, filepath: str | Path, year_energy: float):
         self.filepath = filepath
-        self.data = None
-        self.data_year_energy = None
         self.year_energy = year_energy
         self.load_data()
 
-    def get_daily_stats(self, date_str):
+    def get_daily_stats(self, date_str: str):
         """Returns the 24-hour profile with mean and standard deviation for a given date.
 
         :param date_str: Date as a string in the format "YYYY-MM-DD"
@@ -29,7 +28,7 @@ class LoadForecast:
         daily_stats = self.data_year_energy[day_of_year - 1]  # -1 because indexing starts at 0
         return daily_stats
 
-    def get_hourly_stats(self, date_str, hour):
+    def get_hourly_stats(self, date_str: str, hour: int):
         """Returns the mean and standard deviation for a specific hour of a given date.
 
         :param date_str: Date as a string in the format "YYYY-MM-DD"
@@ -47,7 +46,7 @@ class LoadForecast:
 
         return hourly_stats
 
-    def get_stats_for_date_range(self, start_date_str, end_date_str):
+    def get_stats_for_date_range(self, start_date_str: str, end_date_str: str):
         """Returns the means and standard deviations for a date range.
 
         :param start_date_str: Start date as a string in the format "YYYY-MM-DD"
@@ -83,9 +82,10 @@ class LoadForecast:
 
     def get_price_data(self):
         """Returns price data (currently not implemented)."""
-        return self.price_data
+        raise NotImplementedError
+        # return self.price_data
 
-    def _convert_to_datetime(self, date_str):
+    def _convert_to_datetime(self, date_str: str) -> datetime:
         """Converts a date string to a datetime object."""
         return datetime.strptime(date_str, "%Y-%m-%d")
 

--- a/src/akkudoktoreos/prediction/price_forecast.py
+++ b/src/akkudoktoreos/prediction/price_forecast.py
@@ -3,6 +3,7 @@ import json
 import zoneinfo
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any, Sequence
 
 import numpy as np
 import requests
@@ -10,7 +11,7 @@ import requests
 from akkudoktoreos.config import AppConfig, SetupIncomplete
 
 
-def repeat_to_shape(array, target_shape):
+def repeat_to_shape(array: np.ndarray, target_shape: Sequence[int]) -> np.ndarray:
     # Check if the array fits the target shape
     if len(target_shape) != array.ndim:
         raise ValueError("Array and target shape must have the same number of dimensions")
@@ -25,7 +26,11 @@ def repeat_to_shape(array, target_shape):
 
 class HourlyElectricityPriceForecast:
     def __init__(
-        self, source: str | Path, config: AppConfig, charges=0.000228, use_cache=True
+        self,
+        source: str | Path,
+        config: AppConfig,
+        charges: float = 0.000228,
+        use_cache: bool = True,
     ):  # 228
         self.cache_dir = config.working_dir / config.directories.cache
         self.use_cache = use_cache
@@ -37,7 +42,7 @@ class HourlyElectricityPriceForecast:
         self.charges = charges
         self.prediction_hours = config.eos.prediction_hours
 
-    def load_data(self, source: str | Path):
+    def load_data(self, source: str | Path) -> list[dict[str, Any]]:
         cache_file = self.get_cache_file(source)
         if isinstance(source, str):
             if cache_file.is_file() and not self.is_cache_expired() and self.use_cache:
@@ -61,12 +66,14 @@ class HourlyElectricityPriceForecast:
             raise ValueError(f"Input is not a valid path: {source}")
         return json_data["values"]
 
-    def get_cache_file(self, url):
+    def get_cache_file(self, url: str | Path) -> Path:
+        if isinstance(url, Path):
+            url = str(url)
         hash_object = hashlib.sha256(url.encode())
         hex_dig = hash_object.hexdigest()
         return self.cache_dir / f"cache_{hex_dig}.json"
 
-    def is_cache_expired(self):
+    def is_cache_expired(self) -> bool:
         if not self.cache_time_file.is_file():
             return True
         with self.cache_time_file.open("r") as file:
@@ -74,11 +81,11 @@ class HourlyElectricityPriceForecast:
             last_cache_time = datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S")
         return datetime.now() - last_cache_time > timedelta(hours=1)
 
-    def update_cache_timestamp(self):
+    def update_cache_timestamp(self) -> None:
         with self.cache_time_file.open("w") as file:
             file.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
 
-    def get_price_for_date(self, date_str):
+    def get_price_for_date(self, date_str: str) -> np.ndarray:
         """Returns all prices for the specified date, including the price from 00:00 of the previous day."""
         # Convert date string to datetime object
         date_obj = datetime.strptime(date_str, "%Y-%m-%d")
@@ -108,7 +115,7 @@ class HourlyElectricityPriceForecast:
 
         return np.array(date_prices) / (1000.0 * 100.0) + self.charges
 
-    def get_price_for_daterange(self, start_date_str, end_date_str):
+    def get_price_for_daterange(self, start_date_str: str, end_date_str: str) -> np.ndarray:
         """Returns all prices between the start and end dates."""
         print(start_date_str)
         print(end_date_str)
@@ -117,7 +124,7 @@ class HourlyElectricityPriceForecast:
         start_date = start_date_utc.astimezone(zoneinfo.ZoneInfo("Europe/Berlin"))
         end_date = end_date_utc.astimezone(zoneinfo.ZoneInfo("Europe/Berlin"))
 
-        price_list = []
+        price_list: list[float] = []
 
         while start_date < end_date:
             date_str = start_date.strftime("%Y-%m-%d")
@@ -127,8 +134,10 @@ class HourlyElectricityPriceForecast:
                 price_list.extend(daily_prices)
             start_date += timedelta(days=1)
 
+        price_list_np = np.array(price_list)
+
         # If prediction hours are greater than 0, reshape the price list
         if self.prediction_hours > 0:
-            price_list = repeat_to_shape(np.array(price_list), (self.prediction_hours,))
+            price_list_np = repeat_to_shape(price_list_np, (self.prediction_hours,))
 
-        return price_list
+        return price_list_np

--- a/src/akkudoktoreos/prediction/pv_forecast.py
+++ b/src/akkudoktoreos/prediction/pv_forecast.py
@@ -21,7 +21,7 @@ Example:
     )
 
     # Update the AC power measurement for a specific date and time
-    forecast.update_ac_power_measurement(date_time=datetime.now(), ac_power_measurement=1000)
+    forecast.update_ac_power_measurement(ac_power_measurement=1000, date_time=datetime.now())
 
     # Print the forecast data with DC and AC power details
     forecast.print_ac_power_and_measurement()
@@ -276,8 +276,8 @@ class PVForecast:
 
     def update_ac_power_measurement(
         self,
+        ac_power_measurement: float,
         date_time: Union[datetime, date, str, int, float, None] = None,
-        ac_power_measurement=None,
     ) -> bool:
         """Updates the AC power measurement for a specific time.
 
@@ -467,7 +467,7 @@ class PVForecast:
             data = json.load(file)
         return data
 
-    def load_data_from_url(self, url: str) -> dict:
+    def load_data_from_url(self, url: str) -> dict[str, Any]:
         """Loads forecast data from a URL.
 
         Example:
@@ -488,7 +488,7 @@ class PVForecast:
         return data
 
     @cache_in_file()  # use binary mode by default as we have python objects not text
-    def load_data_from_url_with_caching(self, url: str, until_date=None) -> dict[str, Any]:
+    def load_data_from_url_with_caching(self, url: str) -> dict[str, Any]:
         """Loads data from a URL or from the cache if available.
 
         Args:
@@ -506,7 +506,7 @@ class PVForecast:
             logger.error(data)
         return data
 
-    def get_forecast_data(self):
+    def get_forecast_data(self) -> list[ForecastData]:
         """Returns the forecast data.
 
         Returns:
@@ -516,7 +516,7 @@ class PVForecast:
 
     def get_temperature_forecast_for_date(
         self, input_date: Union[datetime, date, str, int, float, None]
-    ):
+    ) -> np.ndarray:
         """Returns the temperature forecast for a specific date.
 
         Args:
@@ -543,7 +543,7 @@ class PVForecast:
         self,
         start_date: Union[datetime, date, str, int, float, None],
         end_date: Union[datetime, date, str, int, float, None],
-    ):
+    ) -> np.ndarray:
         """Returns the PV forecast for a date range.
 
         Args:
@@ -575,7 +575,7 @@ class PVForecast:
         self,
         start_date: Union[datetime, date, str, int, float, None],
         end_date: Union[datetime, date, str, int, float, None],
-    ):
+    ) -> np.ndarray:
         """Returns the temperature forecast for a given date range.
 
         Args:
@@ -601,7 +601,7 @@ class PVForecast:
         temperature_forecast = [data.get_temperature() for data in date_range_forecast]
         return np.array(temperature_forecast)[: self.prediction_hours]
 
-    def get_forecast_dataframe(self):
+    def get_forecast_dataframe(self) -> pd.DataFrame:
         """Converts the forecast data into a Pandas DataFrame.
 
         Returns:
@@ -678,5 +678,5 @@ if __name__ == "__main__":
         "past_days=5&cellCoEff=-0.36&inverterEfficiency=0.8&albedo=0.25&timezone=Europe%2FBerlin&"
         "hourly=relativehumidity_2m%2Cwindspeed_10m",
     )
-    forecast.update_ac_power_measurement(date_time=datetime.now(), ac_power_measurement=1000)
+    forecast.update_ac_power_measurement(ac_power_measurement=1000, date_time=datetime.now())
     print(forecast.report_ac_power_and_measurement())

--- a/src/akkudoktoreos/server/fastapi_server.py
+++ b/src/akkudoktoreos/server/fastapi_server.py
@@ -182,12 +182,7 @@ def fastapi_pvprognose(url: str, ac_power_measurement: Optional[float] = None) -
     pv_forecast = PVforecast.get_pv_forecast_for_date_range(date_now, date)
     temperature_forecast = PVforecast.get_temperature_for_date_range(date_now, date)
 
-    # Return both forecasts as a JSON response
-    ret = {
-        "temperature": temperature_forecast.tolist(),
-        "pvpower": pv_forecast.tolist(),
-    }
-    return ret
+    return ForecastResponse(temperature=temperature_forecast.tolist(), pvpower=pv_forecast.tolist())
 
 
 @app.post("/optimize")
@@ -203,7 +198,6 @@ def fastapi_optimize(
     # Perform optimization simulation
     result = opt_class.optimierung_ems(parameters=parameters, start_hour=start_hour)
     # print(result)
-    # convert to JSON (None accepted by dumps)
     return result
 
 

--- a/src/akkudoktoreos/server/fastapi_server.py
+++ b/src/akkudoktoreos/server/fastapi_server.py
@@ -120,7 +120,8 @@ def fastapi_gesamtlast(
     leistung_haushalt = future_predictions["Adjusted Pred"].values
     gesamtlast = Gesamtlast(prediction_hours=hours)
     gesamtlast.hinzufuegen(
-        "Haushalt", leistung_haushalt
+        "Haushalt",
+        leistung_haushalt,  # type: ignore[arg-type]
     )  # Add household load to total load calculation
 
     # Calculate the total load
@@ -202,7 +203,7 @@ def fastapi_optimize(
 
 
 @app.get("/visualization_results.pdf", response_class=PdfResponse)
-def get_pdf():
+def get_pdf() -> PdfResponse:
     # Endpoint to serve the generated PDF with visualization results
     output_path = config.working_dir / config.directories.output
     if not output_path.is_dir():
@@ -210,16 +211,16 @@ def get_pdf():
     file_path = output_path / "visualization_results.pdf"
     if not file_path.is_file():
         raise HTTPException(status_code=404, detail="No visualization result available.")
-    return FileResponse(file_path)
+    return PdfResponse(file_path)
 
 
 @app.get("/site-map", include_in_schema=False)
-def site_map():
+def site_map() -> RedirectResponse:
     return RedirectResponse(url="/docs")
 
 
 @app.get("/", include_in_schema=False)
-def root():
+def root() -> RedirectResponse:
     # Redirect the root URL to the site map
     return RedirectResponse(url="/docs")
 

--- a/src/akkudoktoreos/utils/utils.py
+++ b/src/akkudoktoreos/utils/utils.py
@@ -7,7 +7,7 @@ import numpy as np
 
 
 # currently unused
-def ist_dst_wechsel(tag: datetime.datetime, timezone="Europe/Berlin") -> bool:
+def ist_dst_wechsel(tag: datetime.datetime, timezone: str = "Europe/Berlin") -> bool:
     """Checks if Daylight Saving Time (DST) starts or ends on a given day."""
     tz = zoneinfo.ZoneInfo(timezone)
     # Get the current day and the next day
@@ -32,14 +32,14 @@ class NumpyEncoder(json.JSONEncoder):
             return obj.item(), True  # Convert NumPy scalars to native Python types
         return obj, False
 
-    def default(self, obj):
+    def default(self, obj: Any) -> Any:
         obj, converted = NumpyEncoder.convert_numpy(obj)
         if converted:
             return obj
         return super(NumpyEncoder, self).default(obj)
 
     @staticmethod
-    def dumps(data):
+    def dumps(data: Any) -> str:
         """Static method to serialize a Python object into a JSON string using NumpyEncoder.
 
         Args:

--- a/src/akkudoktoreos/utils/utils.py
+++ b/src/akkudoktoreos/utils/utils.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import zoneinfo
+from typing import Any
 
 import numpy as np
 
@@ -20,11 +21,21 @@ def ist_dst_wechsel(tag: datetime.datetime, timezone="Europe/Berlin") -> bool:
 
 
 class NumpyEncoder(json.JSONEncoder):
-    def default(self, obj):
+    @classmethod
+    def convert_numpy(cls, obj: Any) -> tuple[Any, bool]:
         if isinstance(obj, np.ndarray):
-            return obj.tolist()  # Convert NumPy arrays to lists
+            # Convert NumPy arrays to lists
+            return [
+                None if isinstance(x, (int, float)) and np.isnan(x) else x for x in obj.tolist()
+            ], True
         if isinstance(obj, np.generic):
-            return obj.item()  # Convert NumPy scalars to native Python types
+            return obj.item(), True  # Convert NumPy scalars to native Python types
+        return obj, False
+
+    def default(self, obj):
+        obj, converted = NumpyEncoder.convert_numpy(obj)
+        if converted:
+            return obj
         return super(NumpyEncoder, self).default(obj)
 
     @staticmethod

--- a/src/akkudoktoreos/visualize.py
+++ b/src/akkudoktoreos/visualize.py
@@ -1,4 +1,6 @@
 # Set the backend for matplotlib to Agg
+from typing import Any, Optional
+
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
@@ -10,20 +12,20 @@ matplotlib.use("Agg")
 
 
 def visualisiere_ergebnisse(
-    gesamtlast,
-    pv_forecast,
-    strompreise,
-    ergebnisse,
-    ac,  # AC charging allowed
-    dc,  # DC charging allowed
-    discharge,  # Discharge allowed
-    temperature,
-    start_hour,
-    einspeiseverguetung_euro_pro_wh,
+    gesamtlast: list[float],
+    pv_forecast: list[float],
+    strompreise: list[float],
+    ergebnisse: dict[str, Any],
+    ac: np.ndarray,  # AC charging allowed
+    dc: np.ndarray,  # DC charging allowed
+    discharge: np.ndarray,  # Discharge allowed
+    temperature: Optional[list[float]],
+    start_hour: int,
+    einspeiseverguetung_euro_pro_wh: np.ndarray,
     config: AppConfig,
-    filename="visualization_results.pdf",
-    extra_data=None,
-):
+    filename: str = "visualization_results.pdf",
+    extra_data: Optional[dict[str, Any]] = None,
+) -> None:
     #####################
     # 24-hour visualization
     #####################
@@ -81,13 +83,14 @@ def visualisiere_ergebnisse(
         plt.grid(True)
 
         # Temperature forecast
-        plt.subplot(3, 2, 5)
-        plt.title("Temperature Forecast (°C)")
-        plt.plot(hours, temperature, label="Temperature (°C)", marker="x")
-        plt.xlabel("Hour of the Day")
-        plt.ylabel("°C")
-        plt.legend()
-        plt.grid(True)
+        if temperature is not None:
+            plt.subplot(3, 2, 5)
+            plt.title("Temperature Forecast (°C)")
+            plt.plot(hours, temperature, label="Temperature (°C)", marker="x")
+            plt.xlabel("Hour of the Day")
+            plt.ylabel("°C")
+            plt.legend()
+            plt.grid(True)
 
         pdf.savefig()  # Save the current figure state to the PDF
         plt.close()  # Close the current figure to free up memory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from akkudoktoreos.config import EOS_DIR, AppConfig, load_config
 def load_config_tmp(tmp_path: Path) -> AppConfig:
     """Creates an AppConfig from default.config.json with a tmp output directory."""
     config = load_config(tmp_path)
-    config.directories.output = tmp_path
+    config.directories.output = str(tmp_path)
     return config
 
 

--- a/tests/test_class_ems.py
+++ b/tests/test_class_ems.py
@@ -5,10 +5,10 @@ from akkudoktoreos.config import AppConfig
 from akkudoktoreos.devices.battery import EAutoParameters, PVAkku, PVAkkuParameters
 from akkudoktoreos.devices.generic import HomeAppliance, HomeApplianceParameters
 from akkudoktoreos.devices.inverter import Wechselrichter, WechselrichterParameters
-from akkudoktoreos.optimization.genetic import SimulationResult
 from akkudoktoreos.prediction.ems import (
     EnergieManagementSystem,
     EnergieManagementSystemParameters,
+    SimulationResult,
 )
 
 prediction_hours = 48

--- a/tests/test_class_ems.py
+++ b/tests/test_class_ems.py
@@ -5,6 +5,7 @@ from akkudoktoreos.config import AppConfig
 from akkudoktoreos.devices.battery import EAutoParameters, PVAkku, PVAkkuParameters
 from akkudoktoreos.devices.generic import HomeAppliance, HomeApplianceParameters
 from akkudoktoreos.devices.inverter import Wechselrichter, WechselrichterParameters
+from akkudoktoreos.optimization.genetic import SimulationResult
 from akkudoktoreos.prediction.ems import (
     EnergieManagementSystem,
     EnergieManagementSystemParameters,
@@ -211,9 +212,9 @@ def create_ems_instance(tmp_config: AppConfig) -> EnergieManagementSystem:
             preis_euro_pro_wh_akku=preis_euro_pro_wh_akku,
             gesamtlast=gesamtlast,
         ),
+        wechselrichter=wechselrichter,
         eauto=eauto,
         home_appliance=home_appliance,
-        wechselrichter=wechselrichter,
     )
 
     return ems
@@ -255,26 +256,7 @@ def test_simulation(create_ems_instance):
 
     # Check that the result is a dictionary
     assert isinstance(result, dict), "Result should be a dictionary."
-
-    # Verify that the expected keys are present in the result
-    expected_keys = [
-        "Last_Wh_pro_Stunde",
-        "Netzeinspeisung_Wh_pro_Stunde",
-        "Netzbezug_Wh_pro_Stunde",
-        "Kosten_Euro_pro_Stunde",
-        "akku_soc_pro_stunde",
-        "Einnahmen_Euro_pro_Stunde",
-        "Gesamtbilanz_Euro",
-        "EAuto_SoC_pro_Stunde",
-        "Gesamteinnahmen_Euro",
-        "Gesamtkosten_Euro",
-        "Verluste_Pro_Stunde",
-        "Gesamt_Verluste",
-        "Home_appliance_wh_per_hour",
-    ]
-
-    for key in expected_keys:
-        assert key in result, f"The key '{key}' should be present in the result."
+    assert SimulationResult(**result) is not None
 
     # Check the length of the main arrays
     assert (
@@ -344,7 +326,7 @@ def test_simulation(create_ems_instance):
     assert (
         np.nansum(
             np.where(
-                np.equal(result["Home_appliance_wh_per_hour"], None),
+                result["Home_appliance_wh_per_hour"] is None,
                 np.nan,
                 np.array(result["Home_appliance_wh_per_hour"]),
             )

--- a/tests/test_class_ems_2.py
+++ b/tests/test_class_ems_2.py
@@ -44,13 +44,13 @@ def create_ems_instance(tmp_config: AppConfig) -> EnergieManagementSystem:
     )
 
     # Parameters based on previous example data
-    pv_prognose_wh = np.full(prediction_hours, 0)
+    pv_prognose_wh = [0.0] * prediction_hours
     pv_prognose_wh[10] = 5000.0
     pv_prognose_wh[11] = 5000.0
 
-    strompreis_euro_pro_wh = np.full(48, 0.001)
-    strompreis_euro_pro_wh[0:10] = 0.00001
-    strompreis_euro_pro_wh[11:15] = 0.00005
+    strompreis_euro_pro_wh = [0.001] * prediction_hours
+    strompreis_euro_pro_wh[0:10] = [0.00001] * 10
+    strompreis_euro_pro_wh[11:15] = [0.00005] * 4
     strompreis_euro_pro_wh[20] = 0.00001
 
     einspeiseverguetung_euro_pro_wh = [0.00007] * len(strompreis_euro_pro_wh)
@@ -116,9 +116,9 @@ def create_ems_instance(tmp_config: AppConfig) -> EnergieManagementSystem:
             preis_euro_pro_wh_akku=0,
             gesamtlast=gesamtlast,
         ),
+        wechselrichter=wechselrichter,
         eauto=eauto,
         home_appliance=home_appliance,
-        wechselrichter=wechselrichter,
     )
 
     ac = np.full(prediction_hours, 0)

--- a/tests/test_class_optimize.py
+++ b/tests/test_class_optimize.py
@@ -54,7 +54,7 @@ def test_optimize(
 
     file = DIR_TESTDATA / fn_out
     with file.open("r") as f_out:
-        expected_output_data = json.load(f_out)
+        expected_result = OptimizeResponse(**json.load(f_out))
 
     opt_class = optimization_problem(tmp_config, fixed_seed=42)
     start_hour = 10
@@ -72,9 +72,7 @@ def test_optimize(
     # Assert that the output contains all expected entries.
     # This does not assert that the optimization always gives the same result!
     # Reproducibility and mathematical accuracy should be tested on the level of individual components.
-    compare_dict(ergebnis, expected_output_data)
+    compare_dict(ergebnis.model_dump(), expected_result.model_dump())
 
     # The function creates a visualization result PDF as a side-effect.
     visualisiere_ergebnisse_patch.assert_called_once()
-
-    OptimizeResponse(**ergebnis)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,7 +49,7 @@ def test_config_merge(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError):
         # custom configuration is broken but not updated.
-        load_config(tmp_path, tmp_path, False)
+        load_config(tmp_path, True, False)
 
     with config_file.open("r") as f_in:
         # custom configuration is not changed.

--- a/tests/test_pv_forecast.py
+++ b/tests/test_pv_forecast.py
@@ -121,7 +121,7 @@ def test_update_ac_power_measurement(pv_forecast_instance, sample_forecast_start
     forecast_start = pv_forecast_instance.get_forecast_start()
     assert forecast_start == sample_forecast_start
 
-    updated = pv_forecast_instance.update_ac_power_measurement(forecast_start, 1000)
+    updated = pv_forecast_instance.update_ac_power_measurement(1000, forecast_start)
     assert updated is True
     forecast_data = pv_forecast_instance.get_forecast_data()
     assert forecast_data[0].ac_power_measurement == 1000
@@ -130,7 +130,7 @@ def test_update_ac_power_measurement(pv_forecast_instance, sample_forecast_start
 def test_update_ac_power_measurement_no_match(pv_forecast_instance):
     """Test updating AC power measurement where no date matches."""
     date_time = datetime(2023, 10, 2, 1, 0, 0)
-    updated = pv_forecast_instance.update_ac_power_measurement(date_time, 1000)
+    updated = pv_forecast_instance.update_ac_power_measurement(1000, date_time)
     assert not updated
 
 
@@ -265,7 +265,7 @@ def test_timezone_behaviour(
     # Test updating AC power measurement for a specific date.
     date_time = pv_forecast_instance.get_forecast_start()
     assert date_time == sample_forecast_start
-    updated = pv_forecast_instance.update_ac_power_measurement(date_time, 1000)
+    updated = pv_forecast_instance.update_ac_power_measurement(1000, date_time)
     assert updated is True
     forecast_data = pv_forecast_instance.get_forecast_data()
     assert forecast_data[0].ac_power_measurement == 1000


### PR DESCRIPTION
Add Mypy support:
   * Add to pre-commit (currently installs own deps, could maybe changed to poetry venv in the future to reuse environment and don't need duplicated types deps).
   * Add type hints (default mypy config).

In second commit:
   * Add missing annotations.
   * Enforce type hints.

Remarks:
   * Modules not supporting type hints (sklearn, deap, xprocess) and unused code (class_soc_calc.py) are ignored.
   * genetic.py: deap.creator.Individual is hinted as list[int] atm because it inherits from list and is filled with ints.
   * I was a little bit lazy with the numpy arrays and didn't explicitely write the types there.
   * Thanks to the type checking I found a few bugs and wrong hints.