### PR TITLE
Fix electricity price prediction.

### DIFF
--- a/docs/akkudoktoreos/openapi.json
+++ b/docs/akkudoktoreos/openapi.json
@@ -2511,7 +2511,20 @@
               }
             ],
             "title": "Elecprice Provider",
-            "description": "Electicity price provider id of provider to be used."
+            "description": "Electricity price provider id of provider to be used."
+          },
+          "elecprice_charges": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Elecprice Charges",
+            "description": "Electricity price charges (\u20ac/kWh)."
           },
           "prediction_hours": {
             "anyOf": [
@@ -5138,7 +5151,20 @@
               }
             ],
             "title": "Elecprice Provider",
-            "description": "Electicity price provider id of provider to be used."
+            "description": "Electricity price provider id of provider to be used."
+          },
+          "elecprice_charges": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Elecprice Charges",
+            "description": "Electricity price charges (\u20ac/kWh)."
           },
           "prediction_hours": {
             "anyOf": [

--- a/src/akkudoktoreos/prediction/elecprice.py
+++ b/src/akkudoktoreos/prediction/elecprice.py
@@ -7,5 +7,8 @@ from akkudoktoreos.config.configabc import SettingsBaseModel
 
 class ElecPriceCommonSettings(SettingsBaseModel):
     elecprice_provider: Optional[str] = Field(
-        default=None, description="Electicity price provider id of provider to be used."
+        default=None, description="Electricity price provider id of provider to be used."
+    )
+    elecprice_charges: Optional[float] = Field(
+        default=None, ge=0, description="Electricity price charges (€/kWh)."
     )

--- a/src/akkudoktoreos/prediction/elecpriceakkudoktor.py
+++ b/src/akkudoktoreos/prediction/elecpriceakkudoktor.py
@@ -204,22 +204,24 @@ class ElecPriceAkkudoktor(ElecPriceProvider):
         elecprice_cache_file.seek(0)
         self.elecprice_8days = np.load(elecprice_cache_file)
 
+        # Get elecprice_charges
+        charges = self.config.elecprice_charges if self.config.elecprice_charges else 0.0
+
         for i in range(values_len):
             original_datetime = akkudoktor_data.values[i].start
             dt = to_datetime(original_datetime, in_timezone=self.config.timezone)
             akkudoktor_value = akkudoktor_data.values[i]
+            price = akkudoktor_value.marketpriceEurocentPerKWh / 100 + charges
 
             if compare_datetimes(dt, self.start_datetime).lt:
                 # forecast data is too old
-                self.elecprice_8days[dt.hour, dt.day_of_week] = (
-                    akkudoktor_value.marketpriceEurocentPerKWh
-                )
+                self.elecprice_8days[dt.hour, dt.day_of_week] = price
                 continue
-            self.elecprice_8days[dt.hour, 7] = akkudoktor_value.marketpriceEurocentPerKWh
+            self.elecprice_8days[dt.hour, 7] = price
 
             record = ElecPriceDataRecord(
                 date_time=dt,
-                elecprice_marketprice=akkudoktor_value.marketpriceEurocentPerKWh,
+                elecprice_marketprice=price,
             )
             self.append(record)
 


### PR DESCRIPTION
The electricity price prediction provided prices in Eurocent/ kWh despite claiming the price to be in €/ kWh. Also the addition of charges was not possible.

Now prices are provided in €/kWh. Charges can be configured by the `elecprice_charges` configuration option.