### PR TITLE
numpy requires python version 3.10, requirement was 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Installation
 
-The project requires Python 3.9 or newer. Currently there are no official packages or images published.
+The project requires Python 3.10 or newer. Currently there are no official packages or images published.
 
 Following sections describe how to locally start the EOS server on `http://localhost:8503`.
 
@@ -17,12 +17,14 @@ Following sections describe how to locally start the EOS server on `http://local
 Install dependencies in virtual environment:
 
 Linux:
+
 ```bash
 python -m venv .venv
 .venv/bin/pip install -r requirements.txt
 ```
 
 Windows:
+
 ```bash
 python -m venv .venv
  .venv\Scripts\pip install -r requirements.txt
@@ -31,13 +33,17 @@ python -m venv .venv
 Finally, start EOS fastapi server:
 
 Linux:
+
 ```bash
 .venv/bin/fastapi run --port 8503 src/akkudoktoreos/server/fastapi_server.py
 ```
+
 Windows:
+
 ```
  .venv\Scripts\fastapi run --port 8503 src/akkudoktoreos/server/fastapi_server.py
 ```
+
 ### Docker
 
 ```bash
@@ -89,7 +95,6 @@ Each class is designed to be easily customized and extended to integrate additio
 
 See the Swagger API documentation for detailed information: [EOS OpenAPI Spec](https://petstore3.swagger.io/?url=https://raw.githubusercontent.com/Akkudoktor-EOS/EOS/refs/heads/main/docs/akkudoktoreos/openapi.json)
 
-
 ## Further resources
 
- - [Installation guide (de)](https://meintechblog.de/2024/09/05/andreas-schmitz-joerg-installiert-mein-energieoptimierungssystem/)
+- [Installation guide (de)](https://meintechblog.de/2024/09/05/andreas-schmitz-joerg-installiert-mein-energieoptimierungssystem/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 description = "This project provides a comprehensive solution for simulating and optimizing an energy system based on renewable energy sources. With a focus on photovoltaic (PV) systems, battery storage (batteries), load management (consumer requirements), heat pumps, electric vehicles, and consideration of electricity price data, this system enables forecasting and optimization of energy flow and costs over a specified period."
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Clean install of EOS with Python 3.9 requires Python 3.10 due to [numpy dependency](https://pypi.org/project/numpy/2.2.0/).
```
C:\Users\****\Desktop\EOS>.venv\Scripts\pip install -r requirements.txt
ERROR: Ignored the following versions that require a different python version: 2.1.0 Requires-Python >=3.10; 2.1.0rc1 Requires-Python >=3.10; 2.1.1 Requires-Python >=3.10; 2.1.2 Requires-Python >=3.10; 2.1.3 Requires-Python >=3.10; 2.2.0 Requires-Python >=3.10; 2.2.0rc1 Requires-Python >=3.10; 2.2.1 Requires-Python >=3.10
ERROR: Could not find a version that satisfies the requirement numpy==2.2.0 (from versions: 1.3.0, 1.4.1, 1.5.0, 1.5.1, 1.6.0, 1.6.1, 1.6.2, 1.7.0, 1.7.1, 1.7.2, 1.8.0, 1.8.1, 1.8.2, 1.9.0, 1.9.1, 1.9.2, 1.9.3, 1.10.0.post2, 1.10.1, 1.10.2, 1.10.4, 1.11.0, 1.11.1, 1.11.2, 1.11.3, 1.12.0, 1.12.1, 1.13.0, 1.13.1, 1.13.3, 1.14.0, 1.14.1, 1.14.2, 1.14.3, 1.14.4, 1.14.5, 1.14.6, 1.15.0, 1.15.1, 1.15.2, 1.15.3, 1.15.4, 1.16.0, 1.16.1, 1.16.2, 1.16.3, 1.16.4, 1.16.5, 1.16.6, 1.17.0, 1.17.1, 1.17.2, 1.17.3, 1.17.4, 1.17.5, 1.18.0, 1.18.1, 1.18.2, 1.18.3, 1.18.4, 1.18.5, 1.19.0, 1.19.1, 1.19.2, 1.19.3, 1.19.4, 1.19.5, 1.20.0, 1.20.1, 1.20.2, 1.20.3, 1.21.0, 1.21.1, 1.21.2, 1.21.3, 1.21.4, 1.21.5, 1.21.6, 1.22.0, 1.22.1, 1.22.2, 1.22.3, 1.22.4, 1.23.0, 1.23.1, 1.23.2, 1.23.3, 1.23.4, 1.23.5, 1.24.0, 1.24.1, 1.24.2, 1.24.3, 1.24.4, 1.25.0, 1.25.1, 1.25.2, 1.26.0, 1.26.1, 1.26.2, 1.26.3, 1.26.4, 2.0.0, 2.0.1, 2.0.2)
ERROR: No matching distribution found for numpy==2.2.0
```