### PR TITLE
remove outdated exclude in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ testpaths = [ "tests", ]
 
 [tool.mypy]
 files = ["src", "tests"]
-exclude = "class_soc_calc\\.py$"
 check_untyped_defs = true
 warn_unused_ignores = true
 


### PR DESCRIPTION
exclude = "class_soc_calc\\.py$" is no longer a valid file