### PR TITLE
feature: improve price forecast

### DIFF
--- a/src/akkudoktoreos/data/default.config.json
+++ b/src/akkudoktoreos/data/default.config.json
@@ -19,7 +19,7 @@
   "optimization_ev_available_charge_rates_percent": null,
   "optimization_hours": 48,
   "optimization_penalty": null,
-  "prediction_historic_hours": 48,
+  "prediction_historic_hours": 840,
   "prediction_hours": 48,
   "pvforecast0_albedo": null,
   "pvforecast0_inverter_model": null,

--- a/src/akkudoktoreos/prediction/elecpriceakkudoktor.py
+++ b/src/akkudoktoreos/prediction/elecpriceakkudoktor.py
@@ -154,6 +154,8 @@ class ElecPriceAkkudoktor(ElecPriceProvider):
                 0, record
             )  # idk what happens if the date is already there. try except update?
 
+        # now we check if we have data newer than the last from the api. if so thats old prediction. we delete them all.
+
         # now we count how many data points we have.
         # if its > 800 (5 weeks) we will use EST
         # elif > idk maybe 168 (1 week) we use EST without season

--- a/src/akkudoktoreos/prediction/elecpriceakkudoktor.py
+++ b/src/akkudoktoreos/prediction/elecpriceakkudoktor.py
@@ -210,7 +210,7 @@ class ElecPriceAkkudoktor(ElecPriceProvider):
             self.config.elecprice_charges_kwh / 1000 if self.config.elecprice_charges_kwh else 0.0
         )
         assert self.start_datetime  # mypy fix
-        print(akkudoktor_data)
+
         for akkudoktor_value in akkudoktor_data.values:
             orig_datetime = to_datetime(akkudoktor_value.start, in_timezone=self.config.timezone)
 

--- a/tests/test_elecpriceakkudoktor.py
+++ b/tests/test_elecpriceakkudoktor.py
@@ -77,7 +77,7 @@ def test_validate_data_invalid_format(mock_logger, elecprice_provider):
 
 def test_calculate_weighted_mean(elecprice_provider):
     """Test calculation of weighted mean for electricity prices."""
-    elecprice_provider.elecprice_8days = np.random.rand(24, 8) * 100
+    elecprice_provider.elecprice_35days = np.random.rand(24, 35) * 100
     price_mean = elecprice_provider._calculate_weighted_mean(day_of_week=2, hour=10)
     assert isinstance(price_mean, float)
     assert not np.isnan(price_mean)


### PR DESCRIPTION
Modifying elecpriceakkudoktor.py so it can hold up to 5 weeks of data.
Depending on the amount of data we will run different forecasts.
![predictions_vs_true_ets_130](https://github.com/user-attachments/assets/4f942198-20d5-4533-9c97-30ded59a0653)
![metrics_over_iterations_ets_cap_48](https://github.com/user-attachments/assets/0062618c-a0c0-4bb0-834a-462f9a82a85a)
With 5 weeks we will use ets.
