### PR TITLE
Add minimum historic prediction hours for prediction providers.

### DIFF
--- a/src/akkudoktoreos/prediction/elecpriceakkudoktor.py
+++ b/src/akkudoktoreos/prediction/elecpriceakkudoktor.py
@@ -100,6 +100,10 @@ class ElecPriceAkkudoktor(ElecPriceProvider):
             raise ValueError(error_msg)
         return akkudoktor_data
 
+    def historic_hours_min(self) -> int:
+        """Return the minimum historic prediction hours for Akkudoktor electricity price data."""
+        return 5 * 7 * 24  # 5 weeks a 7 days a 24 hours
+
     def _calculate_weighted_mean(self, day_of_week: int, hour: int) -> float:
         """Calculate the weighted mean price for given day_of_week and hour.
 


### PR DESCRIPTION
Prediction providers can now individually set the minimum historic prediction hours to be kept in the data records. This setting supersedes any lower setting given by the configuration `prediction_historic_hours`.

As a help for the future change of ElecPriceAkkudoktor, the minimum historic hours for this provider is set to 5 * 7 * 24 hours.