### PR TITLE
test_elecpriceakkudoktor bugfix

### DIFF
--- a/src/akkudoktoreos/prediction/elecpriceakkudoktor.py
+++ b/src/akkudoktoreos/prediction/elecpriceakkudoktor.py
@@ -189,7 +189,7 @@ class ElecPriceAkkudoktor(ElecPriceProvider):
         )
 
         if needed_prediction_hours <= 0:
-            logger.error(
+            logger.warning(
                 f"No prediction needed. needed_prediction_hours={needed_prediction_hours}, prediction_hours={self.config.prediction_hours},highest_orig_datetime {highest_orig_datetime}, start_datetime {self.start_datetime}"
             )  # this might keep data longer than self.start_datetime + self.config.prediction_hours in the records
             return

--- a/src/akkudoktoreos/prediction/elecpriceakkudoktor.py
+++ b/src/akkudoktoreos/prediction/elecpriceakkudoktor.py
@@ -128,6 +128,7 @@ class ElecPriceAkkudoktor(ElecPriceProvider):
     def _predict_ets(
         self, history: np.ndarray, seasonal_periods: int, prediction_hours: int
     ) -> np.ndarray:
+        print(f"!!!!!!!!!!!history: {history}", seasonal_periods, prediction_hours)
         clean_history = self._cap_outliers(history)
         model = ExponentialSmoothing(
             clean_history, seasonal="add", seasonal_periods=seasonal_periods
@@ -187,6 +188,13 @@ class ElecPriceAkkudoktor(ElecPriceProvider):
             self.config.prediction_hours
             - ((highest_orig_datetime - self.start_datetime).total_seconds() // 3600)
         )
+
+        if needed_prediction_hours <= 0:
+            logger.error(
+                f"No prediction needed. needed_prediction_hours={needed_prediction_hours}, prediction_hours={self.config.prediction_hours},highest_orig_datetime {highest_orig_datetime}, start_datetime {self.start_datetime}"
+            )  # this might keep data longer than self.start_datetime + self.config.prediction_hours in the records
+            return
+
         if amount_datasets > 800:  # we do the full ets with seasons of 1 week
             prediction = self._predict_ets(
                 history, seasonal_periods=168, prediction_hours=needed_prediction_hours

--- a/src/akkudoktoreos/prediction/elecpriceakkudoktor.py
+++ b/src/akkudoktoreos/prediction/elecpriceakkudoktor.py
@@ -128,7 +128,6 @@ class ElecPriceAkkudoktor(ElecPriceProvider):
     def _predict_ets(
         self, history: np.ndarray, seasonal_periods: int, prediction_hours: int
     ) -> np.ndarray:
-        print(f"!!!!!!!!!!!history: {history}", seasonal_periods, prediction_hours)
         clean_history = self._cap_outliers(history)
         model = ExponentialSmoothing(
             clean_history, seasonal="add", seasonal_periods=seasonal_periods


### PR DESCRIPTION
The tests for test_elecpriceakkudoktor.py fail for 2 cases when I run them all at once. However, when I restart the failing tests individually, the error disappears.

I traced the issue to the fact that the forecast hours being requested are negative. This means we somehow have more forecast data in the API response than we originally requested.

What should we do in such cases? Should we enforce the forecast to 0 hours? Should we remove the data from the record that goes too far into the future? How problematic is it if we have more data in the record than we expected, e.g., based on prediction_hours?

This fix would keep the data in the cache but does not try to run a prediction with negative or 0 needed_prediction_hours