### PR TITLE
fix for single_test_optimization.py

### DIFF
--- a/single_test_optimization.py
+++ b/single_test_optimization.py
@@ -140,6 +140,9 @@ def prepare_optimization_real_parameters() -> OptimizationParameters:
                 "max_charge_power_w": 11040,
                 "initial_soc_percentage": 5,
             },
+            "inverter": {
+                "max_power_wh": 10000,
+            },
             "temperature_forecast": temperature_forecast,
             "start_solution": start_solution,
         }
@@ -290,6 +293,9 @@ def prepare_optimization_parameters() -> OptimizationParameters:
                 "charging_efficiency": 0.95,
                 "max_charge_power_w": 11040,
                 "initial_soc_percentage": 5,
+            },
+            "inverter": {
+                "max_power_wh": 10000,
             },
             "temperature_forecast": temperature_forecast,
             "start_solution": start_solution,


### PR DESCRIPTION
no inverter definition was made. properly relied on default settings which are not there anymore. which is a good thing. since the inverter should never be defaulted 