### PR TITLE
Info text for intentional errors

### DIFF
--- a/tests/test_elecpriceakkudoktor.py
+++ b/tests/test_elecpriceakkudoktor.py
@@ -148,7 +148,7 @@ def test_update_data_with_incomplete_forecast(mock_get, provider):
     mock_response.status_code = 200
     mock_response.content = json.dumps(incomplete_data)
     mock_get.return_value = mock_response
-    logger.info("The following errors are intentional and part of the test.")
+    logger.warning("The following errors are intentional and part of the test.")
     with pytest.raises(ValueError):
         provider._update_data(force_update=True)
 

--- a/tests/test_elecpriceakkudoktor.py
+++ b/tests/test_elecpriceakkudoktor.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -8,6 +7,7 @@ import pytest
 import requests
 
 from akkudoktoreos.core.ems import get_ems
+from akkudoktoreos.core.logging import get_logger
 from akkudoktoreos.prediction.elecpriceakkudoktor import (
     AkkudoktorElecPrice,
     AkkudoktorElecPriceValue,
@@ -22,10 +22,7 @@ FILE_TESTDATA_ELECPRICEAKKUDOKTOR_1_JSON = DIR_TESTDATA.joinpath(
     "elecpriceforecast_akkudoktor_1.json"
 )
 
-logger = logging.getLogger(__name__)
-
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+logger = get_logger(__name__)
 
 
 @pytest.fixture

--- a/tests/test_elecpriceakkudoktor.py
+++ b/tests/test_elecpriceakkudoktor.py
@@ -1,11 +1,11 @@
 import json
+import logging
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
 import requests
-import logging
 
 from akkudoktoreos.core.ems import get_ems
 from akkudoktoreos.prediction.elecpriceakkudoktor import (

--- a/tests/test_elecpriceakkudoktor.py
+++ b/tests/test_elecpriceakkudoktor.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pytest
 import requests
+import logging
 
 from akkudoktoreos.core.ems import get_ems
 from akkudoktoreos.prediction.elecpriceakkudoktor import (
@@ -20,6 +21,8 @@ DIR_TESTDATA = Path(__file__).absolute().parent.joinpath("testdata")
 FILE_TESTDATA_ELECPRICEAKKUDOKTOR_1_JSON = DIR_TESTDATA.joinpath(
     "elecpriceforecast_akkudoktor_1.json"
 )
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
@@ -145,6 +148,7 @@ def test_update_data_with_incomplete_forecast(mock_get, provider):
     mock_response.status_code = 200
     mock_response.content = json.dumps(incomplete_data)
     mock_get.return_value = mock_response
+    logger.info("The following errors are intentional and part of the test.")
     with pytest.raises(ValueError):
         provider._update_data(force_update=True)
 

--- a/tests/test_elecpriceakkudoktor.py
+++ b/tests/test_elecpriceakkudoktor.py
@@ -24,6 +24,9 @@ FILE_TESTDATA_ELECPRICEAKKUDOKTOR_1_JSON = DIR_TESTDATA.joinpath(
 
 logger = logging.getLogger(__name__)
 
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+
 
 @pytest.fixture
 def provider(monkeypatch, config_eos):
@@ -148,7 +151,7 @@ def test_update_data_with_incomplete_forecast(mock_get, provider):
     mock_response.status_code = 200
     mock_response.content = json.dumps(incomplete_data)
     mock_get.return_value = mock_response
-    logger.warning("The following errors are intentional and part of the test.")
+    logger.info("The following errors are intentional and part of the test.")
     with pytest.raises(ValueError):
         provider._update_data(force_update=True)
 

--- a/tests/test_pvforecastakkudoktor.py
+++ b/tests/test_pvforecastakkudoktor.py
@@ -23,6 +23,9 @@ FILE_TESTDATA_PV_FORECAST_RESULT_1 = DIR_TESTDATA.joinpath("pv_forecast_result_1
 
 logger = logging.getLogger(__name__)
 
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+
 
 @pytest.fixture
 def sample_settings(config_eos):
@@ -226,7 +229,7 @@ def test_pvforecast_akkudoktor_data_record():
 
 def test_pvforecast_akkudoktor_validate_data(provider_empty_instance, sample_forecast_data_raw):
     """Test validation of PV forecast data on sample data."""
-    logger.warning("The following errors are intentional and part of the test.")
+    logger.info("The following errors are intentional and part of the test.")
     with pytest.raises(
         ValueError,
         match="Field: meta\nError: Field required\nType: missing\nField: values\nError: Field required\nType: missing\n",

--- a/tests/test_pvforecastakkudoktor.py
+++ b/tests/test_pvforecastakkudoktor.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -19,6 +20,8 @@ DIR_TESTDATA = Path(__file__).absolute().parent.joinpath("testdata")
 
 FILE_TESTDATA_PV_FORECAST_INPUT_1 = DIR_TESTDATA.joinpath("pv_forecast_input_1.json")
 FILE_TESTDATA_PV_FORECAST_RESULT_1 = DIR_TESTDATA.joinpath("pv_forecast_result_1.txt")
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture

--- a/tests/test_pvforecastakkudoktor.py
+++ b/tests/test_pvforecastakkudoktor.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -6,6 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from akkudoktoreos.core.ems import get_ems
+from akkudoktoreos.core.logging import get_logger
 from akkudoktoreos.prediction.prediction import get_prediction
 from akkudoktoreos.prediction.pvforecastakkudoktor import (
     AkkudoktorForecastHorizon,
@@ -21,10 +21,7 @@ DIR_TESTDATA = Path(__file__).absolute().parent.joinpath("testdata")
 FILE_TESTDATA_PV_FORECAST_INPUT_1 = DIR_TESTDATA.joinpath("pv_forecast_input_1.json")
 FILE_TESTDATA_PV_FORECAST_RESULT_1 = DIR_TESTDATA.joinpath("pv_forecast_result_1.txt")
 
-logger = logging.getLogger(__name__)
-
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+logger = get_logger(__name__)
 
 
 @pytest.fixture

--- a/tests/test_pvforecastakkudoktor.py
+++ b/tests/test_pvforecastakkudoktor.py
@@ -223,6 +223,7 @@ def test_pvforecast_akkudoktor_data_record():
 
 def test_pvforecast_akkudoktor_validate_data(provider_empty_instance, sample_forecast_data_raw):
     """Test validation of PV forecast data on sample data."""
+    logger.info("The following errors are intentional and part of the test.")
     with pytest.raises(
         ValueError,
         match="Field: meta\nError: Field required\nType: missing\nField: values\nError: Field required\nType: missing\n",

--- a/tests/test_pvforecastakkudoktor.py
+++ b/tests/test_pvforecastakkudoktor.py
@@ -226,7 +226,7 @@ def test_pvforecast_akkudoktor_data_record():
 
 def test_pvforecast_akkudoktor_validate_data(provider_empty_instance, sample_forecast_data_raw):
     """Test validation of PV forecast data on sample data."""
-    logger.info("The following errors are intentional and part of the test.")
+    logger.warning("The following errors are intentional and part of the test.")
     with pytest.raises(
         ValueError,
         match="Field: meta\nError: Field required\nType: missing\nField: values\nError: Field required\nType: missing\n",


### PR DESCRIPTION
Adding an info text before intentional error messages are shown.
Closes #416 

![image](https://github.com/user-attachments/assets/45397dfa-d98e-439b-927c-9ac992a00f43)
