### PR TITLE
EOSdash: Shutdown on EOS termination.

### DIFF
--- a/src/akkudoktoreos/server/eos.py
+++ b/src/akkudoktoreos/server/eos.py
@@ -271,6 +271,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Handover to application
     yield
 
+    if config_eos.server.startup_eosdash:
+        eosdash_process.terminate()
+
     # On shutdown
     cache_save()
 


### PR DESCRIPTION
 * Use Popen.terminate to stop process started in lifespan.