### PR TITLE
Dockerfile: Set default for EOS_SERVER__EOSDASH_SESSKEY Closes #447

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ ENV EOS_CACHE_DIR="${EOS_DIR}/cache"
 ENV EOS_OUTPUT_DIR="${EOS_DIR}/output"
 ENV EOS_CONFIG_DIR="${EOS_DIR}/config"
 
+# Overwrite when starting the container in a production environment
+ENV EOS_SERVER__EOSDASH_SESSKEY=s3cr3t
+
 WORKDIR ${EOS_DIR}
 
 RUN adduser --system --group --no-create-home eos \


### PR DESCRIPTION
 * This allows to start the container without any extra settings (potentially unsafe). It is recommended to set EOS_SERVER__EOSDASH_SESSKEY.