### PR TITLE
CONTRIBUTING.md fix documentation link (404 error)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The `EOS` project is in early development, therefore we encourage contribution i
 
 ## Documentation
 
-Latest development documentation can be found at [Akkudoktor-EOS](https://akkudoktor-eos.readthedocs.io/en/main/).
+Latest development documentation can be found at [Akkudoktor-EOS](https://akkudoktor-eos.readthedocs.io/en/latest/).
 
 ## Bug Reports
 


### PR DESCRIPTION
Fix take over the same link as in README.md. The current link will end up in HTTP error 404 (not found).