### PR TITLE
Close stale pull requests/ issues after 60 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,35 @@
+name: "Close stale pull requests/issues"
+on:
+  schedule:
+  - cron: "16 00 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    name: Find Stale issues and PRs
+    runs-on: ubuntu-22.04
+    if: github.repository == 'Akkudoktor-EOS/EOS'
+    permissions:
+      pull-requests: write # to comment on stale pull requests
+      issues: write        # to comment on stale issues
+
+    steps:
+    - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+      with:
+        stale-pr-message: 'This pull request has been marked as stale because it has been open (more
+          than) 60 days with no activity. Remove the stale label or add a comment saying that you
+          would like to have the label removed otherwise this pull request will automatically be
+          closed in 14 days. Note, that you can always re-open a closed pull request at any time.'
+        stale-issue-message: 'This issue has been marked as stale because it has been open (more
+          than) 60 days with no activity. Remove the stale label or add a comment saying that you
+          would like to have the label removed otherwise this issue will automatically be closed in
+          14 days. Note, that you can always re-open a closed issue at any time.'
+        days-before-stale: 60
+        days-before-close: 14
+        stale-issue-label: 'Stale'
+        stale-pr-label: 'Stale'
+        exempt-pr-labels: 'In progress'
+        exempt-issue-labels: 'In progress,Feature,Feature Request'
+        operations-per-run: 400


### PR DESCRIPTION
Add GitHub workflow to close requests/issues after 60 days of inactivity. Requests/ issues may be blocked from closing by adding the In progress label.