### PR TITLE
fix: relax stale issue/pr handling

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,17 +19,17 @@ jobs:
     - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
       with:
         stale-pr-message: 'This pull request has been marked as stale because it has been open (more
-          than) 60 days with no activity. Remove the stale label or add a comment saying that you
+          than) 90 days with no activity. Remove the stale label or add a comment saying that you
           would like to have the label removed otherwise this pull request will automatically be
-          closed in 14 days. Note, that you can always re-open a closed pull request at any time.'
+          closed in 30 days. Note, that you can always re-open a closed pull request at any time.'
         stale-issue-message: 'This issue has been marked as stale because it has been open (more
-          than) 60 days with no activity. Remove the stale label or add a comment saying that you
+          than) 90 days with no activity. Remove the stale label or add a comment saying that you
           would like to have the label removed otherwise this issue will automatically be closed in
-          14 days. Note, that you can always re-open a closed issue at any time.'
-        days-before-stale: 60
-        days-before-close: 14
-        stale-issue-label: 'Stale'
-        stale-pr-label: 'Stale'
-        exempt-pr-labels: 'In progress'
-        exempt-issue-labels: 'In progress,Feature,Feature Request'
+          30 days. Note, that you can always re-open a closed issue at any time.'
+        days-before-stale: 90
+        days-before-close: 30
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        exempt-pr-labels: 'in progress'
+        exempt-issue-labels: 'feature request, enhancement'
         operations-per-run: 400


### PR DESCRIPTION
Wait 90 days until stale indication, wait another 30 days until closing. Excempt "enhancement" and "feature request" issues from stale handling. Excempt "in progress" pull requests from stale handling.