### PR TITLE
ci(docker): add :latest tag on default branch builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -195,6 +195,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
           labels: |
             org.opencontainers.image.licenses=${{ env.EOS_LICENSE }}
           annotations: |


### PR DESCRIPTION
### What
Adds `:latest` tag to Docker images when building the `main` branch.

### Why
Fixes `docker run akkudoktor/eos` failure due to missing `:latest` tag.  
This change makes it possible to use the image without specifying a version tag.

Fixes #499

### How
Adds `type=raw,value=latest,enable={{is_default_branch}}` to the `merge` job's Docker metadata step.
