### PR TITLE
fix(docker): enable BuildKit support for --mount flag (closes #493)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 ARG PYTHON_VERSION=3.12.7
 FROM python:${PYTHON_VERSION}-slim
 


### PR DESCRIPTION
This PR fixes Docker build issues caused by the use of the --mount flag without BuildKit enabled.

- Adds `# syntax=docker/dockerfile:1.7` to the Dockerfile
- Confirms compatibility with Docker 19.x as reported in issue #493

Closes #493
