### PR TITLE
Activation of venv is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Windows:
 
 ```cmd
 python -m venv .venv
+.venv\Scripts\Activate
 .venv\Scripts\pip install -r requirements.txt
 .venv\Scripts\pip install -e .
 ```


### PR DESCRIPTION
On my windows device the following code was additionally needed to start the virtial environment:
.venv\Scripts\Activate

So I added it to the installation documentation.

Maybe the same is needed on Linux, but not tested from my side.