### PR TITLE
fix: azimuth setting of pvforecastakkudoktor provider

### DIFF
--- a/docs/_generated/config.md
+++ b/docs/_generated/config.md
@@ -574,7 +574,7 @@ Validators:
            "planes": [
                {
                    "surface_tilt": 10.0,
-                   "surface_azimuth": 10.0,
+                   "surface_azimuth": 180.0,
                    "userhorizon": [
                        10.0,
                        20.0,
@@ -596,7 +596,7 @@ Validators:
                },
                {
                    "surface_tilt": 20.0,
-                   "surface_azimuth": 20.0,
+                   "surface_azimuth": 90.0,
                    "userhorizon": [
                        5.0,
                        15.0,
@@ -634,7 +634,7 @@ Validators:
            "planes": [
                {
                    "surface_tilt": 10.0,
-                   "surface_azimuth": 10.0,
+                   "surface_azimuth": 180.0,
                    "userhorizon": [
                        10.0,
                        20.0,
@@ -656,7 +656,7 @@ Validators:
                },
                {
                    "surface_tilt": 20.0,
-                   "surface_azimuth": 20.0,
+                   "surface_azimuth": 90.0,
                    "userhorizon": [
                        5.0,
                        15.0,
@@ -683,8 +683,8 @@ Validators:
                3.5
            ],
            "planes_azimuth": [
-               10.0,
-               20.0
+               180.0,
+               90.0
            ],
            "planes_tilt": [
                10.0,
@@ -746,7 +746,7 @@ Validators:
            "planes": [
                {
                    "surface_tilt": 10.0,
-                   "surface_azimuth": 10.0,
+                   "surface_azimuth": 180.0,
                    "userhorizon": [
                        10.0,
                        20.0,
@@ -768,7 +768,7 @@ Validators:
                },
                {
                    "surface_tilt": 20.0,
-                   "surface_azimuth": 20.0,
+                   "surface_azimuth": 90.0,
                    "userhorizon": [
                        5.0,
                        15.0,
@@ -1004,7 +1004,7 @@ Validators:
            "planes": [
                {
                    "surface_tilt": 10.0,
-                   "surface_azimuth": 10.0,
+                   "surface_azimuth": 180.0,
                    "userhorizon": [
                        10.0,
                        20.0,
@@ -1026,7 +1026,7 @@ Validators:
                },
                {
                    "surface_tilt": 20.0,
-                   "surface_azimuth": 20.0,
+                   "surface_azimuth": 90.0,
                    "userhorizon": [
                        5.0,
                        15.0,

--- a/openapi.json
+++ b/openapi.json
@@ -1594,7 +1594,7 @@
                                     "peakpower": 5.0,
                                     "pvtechchoice": "crystSi",
                                     "strings_per_inverter": 2,
-                                    "surface_azimuth": 10.0,
+                                    "surface_azimuth": 180.0,
                                     "surface_tilt": 10.0,
                                     "trackingtype": 0,
                                     "userhorizon": [
@@ -1613,7 +1613,7 @@
                                     "peakpower": 3.5,
                                     "pvtechchoice": "crystSi",
                                     "strings_per_inverter": 2,
-                                    "surface_azimuth": 20.0,
+                                    "surface_azimuth": 90.0,
                                     "surface_tilt": 20.0,
                                     "trackingtype": 1,
                                     "userhorizon": [
@@ -1701,7 +1701,7 @@
                                     "peakpower": 5.0,
                                     "pvtechchoice": "crystSi",
                                     "strings_per_inverter": 2,
-                                    "surface_azimuth": 10.0,
+                                    "surface_azimuth": 180.0,
                                     "surface_tilt": 10.0,
                                     "trackingtype": 0,
                                     "userhorizon": [
@@ -1720,7 +1720,7 @@
                                     "peakpower": 3.5,
                                     "pvtechchoice": "crystSi",
                                     "strings_per_inverter": 2,
-                                    "surface_azimuth": 20.0,
+                                    "surface_azimuth": 90.0,
                                     "surface_tilt": 20.0,
                                     "trackingtype": 1,
                                     "userhorizon": [
@@ -2036,6 +2036,8 @@
                     "surface_azimuth": {
                         "anyOf": [
                             {
+                                "maximum": 360.0,
+                                "minimum": 0.0,
                                 "type": "number"
                             },
                             {
@@ -2045,14 +2047,16 @@
                         "default": 180.0,
                         "description": "Orientation (azimuth angle) of the (fixed) plane. Clockwise from north (north=0, east=90, south=180, west=270).",
                         "examples": [
-                            10.0,
-                            20.0
+                            180.0,
+                            90.0
                         ],
                         "title": "Surface Azimuth"
                     },
                     "surface_tilt": {
                         "anyOf": [
                             {
+                                "maximum": 90.0,
+                                "minimum": 0.0,
                                 "type": "number"
                             },
                             {

--- a/src/akkudoktoreos/prediction/pvforecast.py
+++ b/src/akkudoktoreos/prediction/pvforecast.py
@@ -28,13 +28,17 @@ class PVForecastPlaneSetting(SettingsBaseModel):
     # latitude: Optional[float] = Field(default=None, description="Latitude in decimal degrees, between -90 and 90, north is positive (ISO 19115) (°)")
     surface_tilt: Optional[float] = Field(
         default=30.0,
+        ge=0.0,
+        le=90.0,
         description="Tilt angle from horizontal plane. Ignored for two-axis tracking.",
         examples=[10.0, 20.0],
     )
     surface_azimuth: Optional[float] = Field(
         default=180.0,
+        ge=0.0,
+        le=360.0,
         description="Orientation (azimuth angle) of the (fixed) plane. Clockwise from north (north=0, east=90, south=180, west=270).",
-        examples=[10.0, 20.0],
+        examples=[180.0, 90.0],
     )
     userhorizon: Optional[List[float]] = Field(
         default=None,

--- a/src/akkudoktoreos/prediction/pvforecastakkudoktor.py
+++ b/src/akkudoktoreos/prediction/pvforecastakkudoktor.py
@@ -27,14 +27,14 @@ Example:
             "planes": [
                 {
                     "peakpower": 5.0,
-                    "surface_azimuth": -10,
+                    "surface_azimuth": 170,
                     "surface_tilt": 7,
                     "userhorizon": [20, 27, 22, 20],
                     "inverter_paco": 10000,
                 },
                 {
                     "peakpower": 4.8,
-                    "surface_azimuth": -90,
+                    "surface_azimuth": 90,
                     "surface_tilt": 7,
                     "userhorizon": [30, 30, 30, 50],
                     "inverter_paco": 10000,
@@ -221,7 +221,12 @@ class PVForecastAkkudoktor(PVForecastProvider):
 
         for i in range(len(self.config.pvforecast.planes)):
             query_params.append(f"power={int(self.config.pvforecast.planes_peakpower[i] * 1000)}")
-            query_params.append(f"azimuth={int(self.config.pvforecast.planes_azimuth[i])}")
+            # EOS orientation of of pv modules in azimuth in degree:
+            #   north=0, east=90, south=180, west=270
+            # Akkudoktor orientation of pv modules in azimuth in degree:
+            #   north=+-180, east=-90, south=0, west=90
+            azimuth_akkudoktor = int(self.config.pvforecast.planes_azimuth[i]) - 180
+            query_params.append(f"azimuth={azimuth_akkudoktor}")
             query_params.append(f"tilt={int(self.config.pvforecast.planes_tilt[i])}")
             query_params.append(
                 f"powerInverter={int(self.config.pvforecast.planes_inverter_paco[i])}"
@@ -390,28 +395,28 @@ if __name__ == "__main__":
             "planes": [
                 {
                     "peakpower": 5.0,
-                    "surface_azimuth": -10,
+                    "surface_azimuth": 170,
                     "surface_tilt": 7,
                     "userhorizon": [20, 27, 22, 20],
                     "inverter_paco": 10000,
                 },
                 {
                     "peakpower": 4.8,
-                    "surface_azimuth": -90,
+                    "surface_azimuth": 90,
                     "surface_tilt": 7,
                     "userhorizon": [30, 30, 30, 50],
                     "inverter_paco": 10000,
                 },
                 {
                     "peakpower": 1.4,
-                    "surface_azimuth": -40,
+                    "surface_azimuth": 140,
                     "surface_tilt": 60,
                     "userhorizon": [60, 30, 0, 30],
                     "inverter_paco": 2000,
                 },
                 {
                     "peakpower": 1.6,
-                    "surface_azimuth": 5,
+                    "surface_azimuth": 185,
                     "surface_tilt": 45,
                     "userhorizon": [45, 25, 30, 60],
                     "inverter_paco": 1400,

--- a/src/akkudoktoreos/server/dash/data/democonfig.json
+++ b/src/akkudoktoreos/server/dash/data/democonfig.json
@@ -24,7 +24,7 @@
     "planes": [
       {
         "peakpower": 5.0,
-        "surface_azimuth": -10,
+        "surface_azimuth": 170,
         "surface_tilt": 7,
         "userhorizon": [
           20,
@@ -36,7 +36,7 @@
       },
       {
         "peakpower": 4.8,
-        "surface_azimuth": -90,
+        "surface_azimuth": 90,
         "surface_tilt": 7,
         "userhorizon": [
           30,
@@ -48,7 +48,7 @@
       },
       {
         "peakpower": 1.4,
-        "surface_azimuth": -40,
+        "surface_azimuth": 140,
         "surface_tilt": 60,
         "userhorizon": [
           60,
@@ -60,7 +60,7 @@
       },
       {
         "peakpower": 1.6,
-        "surface_azimuth": 5,
+        "surface_azimuth": 185,
         "surface_tilt": 45,
         "userhorizon": [
           45,

--- a/tests/test_eosdashconfig.py
+++ b/tests/test_eosdashconfig.py
@@ -95,7 +95,7 @@ class TestEOSdashConfig:
             PVForecastPlaneSetting(), values, values_prefix=["pvforecast", "planes", "0"]
         )
         assert any(
-            item["name"] == "pvforecast.planes.0.surface_azimuth" and item["value"] == "-10"
+            item["name"] == "pvforecast.planes.0.surface_azimuth" and item["value"] == "170"
             for item in config
         )
         assert any(

--- a/tests/test_pvforecastakkudoktor.py
+++ b/tests/test_pvforecastakkudoktor.py
@@ -41,28 +41,28 @@ def sample_settings(config_eos):
             "planes": [
                 {
                     "peakpower": 5.0,
-                    "surface_azimuth": -10,
+                    "surface_azimuth": 170,
                     "surface_tilt": 7,
                     "userhorizon": [20, 27, 22, 20],
                     "inverter_paco": 10000,
                 },
                 {
                     "peakpower": 4.8,
-                    "surface_azimuth": -90,
+                    "surface_azimuth": 90,
                     "surface_tilt": 7,
                     "userhorizon": [30, 30, 30, 50],
                     "inverter_paco": 10000,
                 },
                 {
                     "peakpower": 1.4,
-                    "surface_azimuth": -40,
+                    "surface_azimuth": 140,
                     "surface_tilt": 60,
                     "userhorizon": [60, 30, 0, 30],
                     "inverter_paco": 2000,
                 },
                 {
                     "peakpower": 1.6,
-                    "surface_azimuth": 5,
+                    "surface_azimuth": 185,
                     "surface_tilt": 45,
                     "userhorizon": [45, 25, 30, 60],
                     "inverter_paco": 1400,

--- a/tests/testdata/eosserver_config_1.json
+++ b/tests/testdata/eosserver_config_1.json
@@ -24,7 +24,7 @@
     "planes": [
       {
         "peakpower": 5.0,
-        "surface_azimuth": -10,
+        "surface_azimuth": 170,
         "surface_tilt": 7,
         "userhorizon": [
           20,
@@ -36,7 +36,7 @@
       },
       {
         "peakpower": 4.8,
-        "surface_azimuth": -90,
+        "surface_azimuth": 90,
         "surface_tilt": 7,
         "userhorizon": [
           30,
@@ -48,7 +48,7 @@
       },
       {
         "peakpower": 1.4,
-        "surface_azimuth": -40,
+        "surface_azimuth": 140,
         "surface_tilt": 60,
         "userhorizon": [
           60,
@@ -60,7 +60,7 @@
       },
       {
         "peakpower": 1.6,
-        "surface_azimuth": 5,
+        "surface_azimuth": 185,
         "surface_tilt": 45,
         "userhorizon": [
           45,


### PR DESCRIPTION
EOS now enforces the general azimuth definition as e.g. defined in ISO 19111: north=0, east=90, south=180, west=270. This is the convention that is and was in the EOS documentation.

As the PV forecast of akkudoktor.net follows a different convention (north=+-180, east=-90, south=0, west=90) the values from EOS are now converted before the request is sent to akkudoktor.net.

BREAKING CHANGE: Azimuth configurations that followed the PVForecastAkkudoktor convention (north=+-180, east=-90, south=0, west=90) must be converted to the general azimuth definition: north=0, east=90, south=180, west=270.

Fixes: #564 