### PR TITLE
fix: add required fields to example optimization request

### DIFF
--- a/docs/akkudoktoreos/optimization.md
+++ b/docs/akkudoktoreos/optimization.md
@@ -21,6 +21,7 @@ including electricity prices, battery storage capacity, PV forecast, and tempera
         "strompreis_euro_pro_wh": [0.0003784, 0.0003868, ..., 0.00034102, 0.00033709]
     },
     "pv_akku": {
+        "device_id": "battery1",
         "capacity_wh": 12000,
         "charging_efficiency": 0.92,
         "discharging_efficiency": 0.92,
@@ -30,9 +31,12 @@ including electricity prices, battery storage capacity, PV forecast, and tempera
         "max_soc_percentage": 100
     },
     "inverter": {
+        "device_id": "inverter1",
         "max_power_wh": 15500
+        "battery_id": "battery1",
     },
     "eauto": {
+        "device_id": "auto1",
         "capacity_wh": 64000,
         "charging_efficiency": 0.88,
         "discharging_efficiency": 0.88,


### PR DESCRIPTION
otherwise it fails with:


```
{
  "detail": [
    {
      "type": "missing",
      "loc": [
        "body",
        "pv_akku",
        "device_id"
      ],
      "msg": "Field required",
      "input": {
        "capacity_wh": 12000,
        "charging_efficiency": 0.92,
        "discharging_efficiency": 0.92,
        "max_charge_power_w": 5700,
        "initial_soc_percentage": 66,
        "min_soc_percentage": 5,
        "max_soc_percentage": 100
      }
    },
    {
      "type": "missing",
      "loc": [
        "body",
        "inverter",
        "device_id"
      ],
      "msg": "Field required",
      "input": {
        "max_power_wh": 15500
      }
    },
    {
      "type": "missing",
      "loc": [
        "body",
        "eauto",
        "device_id"
      ],
      "msg": "Field required",
      "input": {
        "capacity_wh": 64000,
        "charging_efficiency": 0.88,
        "discharging_efficiency": 0.88,
        "max_charge_power_w": 11040,
        "initial_soc_percentage": 98,
        "min_soc_percentage": 60,
        "max_soc_percentage": 100
      }
    }
  ]
}
```

```
{
  "detail": "Optimize error: Battery for PV inverter is mandatory.."
}
```
I think this one is not necessary if it is part of the config.



The parameters should also be explained in the doc.