### PR TITLE
fix(docker): make EOSDash accessible in Docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,19 @@ RUN mkdir -p src && pip install -e .
 
 COPY src src
 
+# Create minimal default configuration for Docker to fix EOSDash accessibility (#629)
+# This ensures EOSDash binds to 0.0.0.0 instead of 127.0.0.1 in containers
+RUN echo '{\n\
+  "server": {\n\
+    "host": "0.0.0.0",\n\
+    "port": 8503,\n\
+    "startup_eosdash": true,\n\
+    "eosdash_host": "0.0.0.0",\n\
+    "eosdash_port": 8504\n\
+  }\n\
+}' > "${EOS_CONFIG_DIR}/EOS.config.json" \
+    && chown eos:eos "${EOS_CONFIG_DIR}/EOS.config.json"
+
 USER eos
 ENTRYPOINT []
 


### PR DESCRIPTION
Fixes the issue where EOSDash is not accessible when running EOS in a Docker container. The problem was that EOSDash was binding to 127.0.0.1 (localhost) by default, making it inaccessible from outside the container.

The fix adds a minimal default configuration file during the Docker image build that sets both the EOS server and EOSDash to bind to 0.0.0.0, allowing external access while maintaining security through Docker's network isolation.

- Add default EOS.config.json in Dockerfile with server bindings set to 0.0.0.0
- No changes required to docker-compose.yaml
- Ensures EOSDash works out of the box for Docker users

Fixes: #629
Closes: https://github.com/Akkudoktor-EOS/EOS/issues/629