### PR TITLE
fix: handle float values in userhorizon configuration

### DIFF
--- a/src/akkudoktoreos/prediction/pvforecastakkudoktor.py
+++ b/src/akkudoktoreos/prediction/pvforecastakkudoktor.py
@@ -254,7 +254,7 @@ class PVForecastAkkudoktor(PVForecastProvider):
                 f"powerInverter={int(self.config.pvforecast.planes_inverter_paco[i])}"
             )
             horizon_values = ",".join(
-                str(int(h)) for h in self.config.pvforecast.planes_userhorizon[i]
+                str(round(h)) for h in self.config.pvforecast.planes_userhorizon[i]
             )
             query_params.append(f"horizont={horizon_values}")
 


### PR DESCRIPTION
Replace int() with round() when converting userhorizon values to properly handle float values in the configuration. This prevents validation errors when users provide horizon angles with decimal precision.

The Akkudoktor API expects integer values, so rounding to the nearest integer maintains compatibility while accepting float inputs.

Fixes #647
