### PR TITLE
fix: make cache clear endpoint clear all cache by default

### DIFF
--- a/src/akkudoktoreos/server/eos.py
+++ b/src/akkudoktoreos/server/eos.py
@@ -328,17 +328,21 @@ class PdfResponse(FileResponse):
 
 @app.post("/v1/admin/cache/clear", tags=["admin"])
 def fastapi_admin_cache_clear_post(clear_all: Optional[bool] = None) -> dict:
-    """Clear the cache from expired data.
+    """Clear the cache.
 
-    Deletes expired cache files.
+    Deletes cache files. By default, clears all cache files to ensure fresh data
+    on next request. Set clear_all=false to only clear expired cache files.
 
     Args:
-        clear_all (Optional[bool]): Delete all cached files. Default is False.
+        clear_all (Optional[bool]): Delete all cached files. Default is True when not specified.
 
     Returns:
         data (dict): The management data after cleanup.
     """
     try:
+        # Default to clearing all cache when parameter is not specified
+        if clear_all is None:
+            clear_all = True
         cache_clear(clear_all=clear_all)
         data = CacheFileStore().current_store()
     except Exception as e:


### PR DESCRIPTION
Change the /v1/admin/cache/clear endpoint to clear all cache files by default when no parameter is specified. This ensures users get fresh data after calling the endpoint.

Previously, the endpoint only cleared expired cache files by default, which left active cache files unchanged. Users expected all cache to be cleared, leading to confusion when old data was still served.

The clear_all parameter can now be explicitly set to false to only clear expired cache files when needed.

Fixes #646