### PR TITLE
docs: Add Docker volume mount configuration instructions

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,3 +24,22 @@ services:
       # Configure what ports to expose on host
       - "${EOS_SERVER__PORT}:8503"
       - "${EOS_SERVER__EOSDASH_PORT}:8504"
+
+    # Volume mount configuration (optional)
+    # IMPORTANT: When mounting local directories, the default config won't be available.
+    # You must create an EOS.config.json file in your local config directory with:
+    # {
+    #   "server": {
+    #     "host": "0.0.0.0",        # Required for Docker container accessibility
+    #     "port": 8503,
+    #     "startup_eosdash": true,
+    #     "eosdash_host": "0.0.0.0", # Required for Docker container accessibility
+    #     "eosdash_port": 8504
+    #   }
+    # }
+    #
+    # Example volume mounts (uncomment to use):
+    # volumes:
+    #   - ./config:/opt/eos/config     # Mount local config directory
+    #   - ./cache:/opt/eos/cache       # Mount local cache directory
+    #   - ./output:/opt/eos/output     # Mount local output directory


### PR DESCRIPTION
This PR addresses issue #661 by adding clear documentation to the docker-compose.yaml file about the configuration requirements when using volume mounts.

Problem:  
When users mount local directories to the Docker container, the default configuration file created during the Docker build phase is overridden. This causes the frontend to become inaccessible because the server binds to 127.0.0.1 instead of 0.0.0.0. Users will typically add their volume mounts directly in the docker-compose.yaml file, but if they are not aware that they need a specific configuration with 0.0.0.0 bindings, they will  encounter connection issues and the dashboard becomes inaccessible.

Solution

  Added comprehensive documentation in docker-compose.yaml that:
  - Explains why the default config is lost when mounting volumes
  - Provides the required EOS.config.json content with 0.0.0.0 host bindings
  - Includes commented-out volume mount examples for easy reference
  - Warns users directly where they would add volume mounts about the configuration requirement

  Related Issue

  Fixes #661

