### PR TITLE
Fix horizon float validation

### DIFF
--- a/src/akkudoktoreos/prediction/pvforecastakkudoktor.py
+++ b/src/akkudoktoreos/prediction/pvforecastakkudoktor.py
@@ -92,8 +92,8 @@ from akkudoktoreos.utils.datetimeutil import compare_datetimes, to_datetime
 
 class AkkudoktorForecastHorizon(PydanticBaseModel):
     altitude: int
-    azimuthFrom: int
-    azimuthTo: int
+    azimuthFrom: float
+    azimuthTo: float
 
 
 class AkkudoktorForecastMeta(PydanticBaseModel):


### PR DESCRIPTION
# Fix horizon validation for non-integer angle divisions
     ## Summary
     Fixes #647 - Changes `azimuthFrom` and `azimuthTo` fields from `int` to `float` type to handle horizon configurations where 360° doesn't divide evenly (e.g., 32 or 48 values).
     ## Problem
     Validation error occurred with certain `userhorizon` array sizes:
     - 32 values → 360° ÷ 32 = 11.25° (non-integer)
     - 48 values → 360° ÷ 48 = 7.5° (non-integer)
     … +12 lines (ctrl+r to expand)
