### PR TITLE
Feature/api english translation

### DIFF
--- a/src/akkudoktoreos/core/ems.py
+++ b/src/akkudoktoreos/core/ems.py
@@ -19,31 +19,37 @@ from akkudoktoreos.utils.utils import NumpyEncoder
 
 
 class EnergyManagementParameters(ParametersBaseModel):
-    pv_prognose_wh: list[float] = Field(
-        description="An array of floats representing the forecasted photovoltaic output in watts for different time intervals."
+    model_config = ConfigDict(populate_by_name=True)
+    pv_forecast_wh: list[float] = Field(
+        description="An array of floats representing the forecasted photovoltaic output in watts for different time intervals.",
+        alias="pv_prognose_wh"
     )
-    strompreis_euro_pro_wh: list[float] = Field(
-        description="An array of floats representing the electricity price in euros per watt-hour for different time intervals."
+    electricity_price_euro_per_wh: list[float] = Field(
+        description="An array of floats representing the electricity price in euros per watt-hour for different time intervals.",
+        alias="strompreis_euro_pro_wh"
     )
-    einspeiseverguetung_euro_pro_wh: list[float] | float = Field(
-        description="A float or array of floats representing the feed-in compensation in euros per watt-hour."
+    feed_in_tariff_euro_per_wh: list[float] | float = Field(
+        description="A float or array of floats representing the feed-in compensation in euros per watt-hour.",
+        alias="einspeiseverguetung_euro_pro_wh"
     )
-    preis_euro_pro_wh_akku: float = Field(
-        description="A float representing the cost of battery energy per watt-hour."
+    price_euro_per_wh_battery: float = Field(
+        description="A float representing the cost of battery energy per watt-hour.",
+        alias="preis_euro_pro_wh_akku"
     )
-    gesamtlast: list[float] = Field(
-        description="An array of floats representing the total load (consumption) in watts for different time intervals."
+    total_load: list[float] = Field(
+        description="An array of floats representing the total load (consumption) in watts for different time intervals.",
+        alias="gesamtlast"
     )
 
     @model_validator(mode="after")
     def validate_list_length(self) -> Self:
-        pv_prognose_length = len(self.pv_prognose_wh)
+        pv_forecast_length = len(self.pv_forecast_wh)
         if (
-            pv_prognose_length != len(self.strompreis_euro_pro_wh)
-            or pv_prognose_length != len(self.gesamtlast)
+            pv_forecast_length != len(self.electricity_price_euro_per_wh)
+            or pv_forecast_length != len(self.total_load)
             or (
-                isinstance(self.einspeiseverguetung_euro_pro_wh, list)
-                and pv_prognose_length != len(self.einspeiseverguetung_euro_pro_wh)
+                isinstance(self.feed_in_tariff_euro_per_wh, list)
+                and pv_forecast_length != len(self.feed_in_tariff_euro_per_wh)
             )
         ):
             raise ValueError("Input lists have different lengths")
@@ -52,53 +58,73 @@ class EnergyManagementParameters(ParametersBaseModel):
 
 class SimulationResult(ParametersBaseModel):
     """This object contains the results of the simulation and provides insights into various parameters over the entire forecast period."""
+    
+    model_config = ConfigDict(populate_by_name=True)
 
-    Last_Wh_pro_Stunde: list[Optional[float]] = Field(description="TBD")
-    EAuto_SoC_pro_Stunde: list[Optional[float]] = Field(
-        description="The state of charge of the EV for each hour."
+    load_wh_per_hour: list[Optional[float]] = Field(
+        description="TBD",
+        alias="Last_Wh_pro_Stunde"
     )
-    Einnahmen_Euro_pro_Stunde: list[Optional[float]] = Field(
-        description="The revenue from grid feed-in or other sources in euros per hour."
+    ev_soc_per_hour: list[Optional[float]] = Field(
+        description="The state of charge of the EV for each hour.",
+        alias="EAuto_SoC_pro_Stunde"
     )
-    Gesamt_Verluste: float = Field(
-        description="The total losses in watt-hours over the entire period."
+    revenue_euro_per_hour: list[Optional[float]] = Field(
+        description="The revenue from grid feed-in or other sources in euros per hour.",
+        alias="Einnahmen_Euro_pro_Stunde"
     )
-    Gesamtbilanz_Euro: float = Field(
-        description="The total balance of revenues minus costs in euros."
+    total_losses: float = Field(
+        description="The total losses in watt-hours over the entire period.",
+        alias="Gesamt_Verluste"
     )
-    Gesamteinnahmen_Euro: float = Field(description="The total revenues in euros.")
-    Gesamtkosten_Euro: float = Field(description="The total costs in euros.")
+    total_balance_euro: float = Field(
+        description="The total balance of revenues minus costs in euros.",
+        alias="Gesamtbilanz_Euro"
+    )
+    total_revenue_euro: float = Field(
+        description="The total revenues in euros.",
+        alias="Gesamteinnahmen_Euro"
+    )
+    total_costs_euro: float = Field(
+        description="The total costs in euros.",
+        alias="Gesamtkosten_Euro"
+    )
     Home_appliance_wh_per_hour: list[Optional[float]] = Field(
         description="The energy consumption of a household appliance in watt-hours per hour."
     )
-    Kosten_Euro_pro_Stunde: list[Optional[float]] = Field(
-        description="The costs in euros per hour."
+    costs_euro_per_hour: list[Optional[float]] = Field(
+        description="The costs in euros per hour.",
+        alias="Kosten_Euro_pro_Stunde"
     )
-    Netzbezug_Wh_pro_Stunde: list[Optional[float]] = Field(
-        description="The grid energy drawn in watt-hours per hour."
+    grid_consumption_wh_per_hour: list[Optional[float]] = Field(
+        description="The grid energy drawn in watt-hours per hour.",
+        alias="Netzbezug_Wh_pro_Stunde"
     )
-    Netzeinspeisung_Wh_pro_Stunde: list[Optional[float]] = Field(
-        description="The energy fed into the grid in watt-hours per hour."
+    grid_feed_in_wh_per_hour: list[Optional[float]] = Field(
+        description="The energy fed into the grid in watt-hours per hour.",
+        alias="Netzeinspeisung_Wh_pro_Stunde"
     )
-    Verluste_Pro_Stunde: list[Optional[float]] = Field(
-        description="The losses in watt-hours per hour."
+    losses_per_hour: list[Optional[float]] = Field(
+        description="The losses in watt-hours per hour.",
+        alias="Verluste_Pro_Stunde"
     )
-    akku_soc_pro_stunde: list[Optional[float]] = Field(
-        description="The state of charge of the battery (not the EV) in percentage per hour."
+    battery_soc_per_hour: list[Optional[float]] = Field(
+        description="The state of charge of the battery (not the EV) in percentage per hour.",
+        alias="akku_soc_pro_stunde"
     )
     Electricity_price: list[Optional[float]] = Field(
         description="Used Electricity Price, including predictions"
     )
 
     @field_validator(
-        "Last_Wh_pro_Stunde",
-        "Netzeinspeisung_Wh_pro_Stunde",
-        "akku_soc_pro_stunde",
-        "Netzbezug_Wh_pro_Stunde",
-        "Kosten_Euro_pro_Stunde",
-        "Einnahmen_Euro_pro_Stunde",
-        "EAuto_SoC_pro_Stunde",
-        "Verluste_Pro_Stunde",
+        "load_wh_per_hour",
+        "grid_feed_in_wh_per_hour",
+        "battery_soc_per_hour",
+        "grid_consumption_wh_per_hour",
+        "costs_euro_per_hour",
+        "revenue_euro_per_hour",
+        "ev_soc_per_hour",
+        "losses_per_hour",
         "Home_appliance_wh_per_hour",
         "Electricity_price",
         mode="before",
@@ -198,14 +224,14 @@ class EnergyManagement(SingletonMixin, ConfigMixin, PredictionMixin, PydanticBas
         home_appliance: Optional[HomeAppliance] = None,
         inverter: Optional[Inverter] = None,
     ) -> None:
-        self.load_energy_array = np.array(parameters.gesamtlast, float)
-        self.pv_prediction_wh = np.array(parameters.pv_prognose_wh, float)
-        self.elect_price_hourly = np.array(parameters.strompreis_euro_pro_wh, float)
+        self.load_energy_array = np.array(parameters.total_load, float)
+        self.pv_prediction_wh = np.array(parameters.pv_forecast_wh, float)
+        self.elect_price_hourly = np.array(parameters.electricity_price_euro_per_wh, float)
         self.elect_revenue_per_hour_arr = (
-            parameters.einspeiseverguetung_euro_pro_wh
-            if isinstance(parameters.einspeiseverguetung_euro_pro_wh, list)
+            parameters.feed_in_tariff_euro_per_wh
+            if isinstance(parameters.feed_in_tariff_euro_per_wh, list)
             else np.full(
-                len(self.load_energy_array), parameters.einspeiseverguetung_euro_pro_wh, float
+                len(self.load_energy_array), parameters.feed_in_tariff_euro_per_wh, float
             )
         )
         if inverter:
@@ -446,14 +472,14 @@ class EnergyManagement(SingletonMixin, ConfigMixin, PredictionMixin, PydanticBas
 
             # E-Auto handling
             if ev and ev_charge_hours[hour] > 0:
-                loaded_energy_ev, verluste_eauto = ev.charge_energy(
+                loaded_energy_ev, ev_losses = ev.charge_energy(
                     None, hour, relative_power=ev_charge_hours[hour]
                 )
                 consumption += loaded_energy_ev
-                losses_wh_per_hour[hour_idx] += verluste_eauto
+                losses_wh_per_hour[hour_idx] += ev_losses
 
             # Process inverter logic
-            energy_feedin_grid_actual = energy_consumption_grid_actual = losses = eigenverbrauch = (
+            energy_feedin_grid_actual = energy_consumption_grid_actual = losses = self_consumption = (
                 0.0
             )
 
@@ -470,7 +496,7 @@ class EnergyManagement(SingletonMixin, ConfigMixin, PredictionMixin, PydanticBas
                     energy_feedin_grid_actual,
                     energy_consumption_grid_actual,
                     losses,
-                    eigenverbrauch,
+                    self_consumption,
                 ) = inverter.process_energy(energy_produced, consumption, hour)
 
             # AC PV Battery Charge
@@ -502,18 +528,18 @@ class EnergyManagement(SingletonMixin, ConfigMixin, PredictionMixin, PydanticBas
 
         # Prepare output dictionary
         return {
-            "Last_Wh_pro_Stunde": loads_energy_per_hour,
-            "Netzeinspeisung_Wh_pro_Stunde": feedin_energy_per_hour,
-            "Netzbezug_Wh_pro_Stunde": consumption_energy_per_hour,
-            "Kosten_Euro_pro_Stunde": costs_per_hour,
-            "akku_soc_pro_stunde": soc_per_hour,
-            "Einnahmen_Euro_pro_Stunde": revenue_per_hour,
-            "Gesamtbilanz_Euro": total_cost - total_revenue,
-            "EAuto_SoC_pro_Stunde": soc_ev_per_hour,
-            "Gesamteinnahmen_Euro": total_revenue,
-            "Gesamtkosten_Euro": total_cost,
-            "Verluste_Pro_Stunde": losses_wh_per_hour,
-            "Gesamt_Verluste": total_losses,
+            "load_wh_per_hour": loads_energy_per_hour,
+            "grid_feed_in_wh_per_hour": feedin_energy_per_hour,
+            "grid_consumption_wh_per_hour": consumption_energy_per_hour,
+            "costs_euro_per_hour": costs_per_hour,
+            "battery_soc_per_hour": soc_per_hour,
+            "revenue_euro_per_hour": revenue_per_hour,
+            "total_balance_euro": total_cost - total_revenue,
+            "ev_soc_per_hour": soc_ev_per_hour,
+            "total_revenue_euro": total_revenue,
+            "total_costs_euro": total_cost,
+            "losses_per_hour": losses_wh_per_hour,
+            "total_losses": total_losses,
             "Home_appliance_wh_per_hour": home_appliance_wh_per_hour,
             "Electricity_price": electricity_price_per_hour,
         }

--- a/src/akkudoktoreos/optimization/genetic.py
+++ b/src/akkudoktoreos/optimization/genetic.py
@@ -42,7 +42,7 @@ class OptimizationParameters(ParametersBaseModel):
 
     @model_validator(mode="after")
     def validate_list_length(self) -> Self:
-        arr_length = len(self.ems.pv_prognose_wh)
+        arr_length = len(self.ems.pv_forecast_wh)
         if self.temperature_forecast is not None and arr_length != len(self.temperature_forecast):
             raise ValueError("Input lists have different lengths")
         return self
@@ -485,7 +485,7 @@ class optimization_problem(ConfigMixin, DevicesMixin, EnergyManagementSystemMixi
 
         # Adjust total balance with battery value and penalties for unmet SOC
         restwert_akku = (
-            self.ems.battery.current_energy_content() * parameters.ems.preis_euro_pro_wh_akku
+            self.ems.battery.current_energy_content() * parameters.ems.price_per_wh_battery
         )
         gesamtbilanz += -restwert_akku
 
@@ -565,7 +565,7 @@ class optimization_problem(ConfigMixin, DevicesMixin, EnergyManagementSystemMixi
             start_hour = self.ems.start_datetime.hour
 
         einspeiseverguetung_euro_pro_wh = np.full(
-            self.config.prediction.hours, parameters.ems.einspeiseverguetung_euro_pro_wh
+            self.config.prediction.hours, parameters.ems.feed_in_tariff_per_wh
         )
 
         # TODO: Refactor device setup phase out

--- a/src/akkudoktoreos/server/eos.py
+++ b/src/akkudoktoreos/server/eos.py
@@ -960,8 +960,9 @@ def fastapi_prediction_update_provider(
     return Response()
 
 
-@app.get("/strompreis", tags=["prediction"])
-def fastapi_strompreis() -> list[float]:
+@app.get("/electricity_price", tags=["prediction"])
+@app.get("/strompreis", tags=["prediction"], deprecated=True)  # Keep for backward compatibility
+def fastapi_electricity_price() -> list[float]:
     """Deprecated: Electricity Market Price Prediction per Wh (€/Wh).
 
     Electricity prices start at 00.00.00 today and are provided for 48 hours.
@@ -1008,14 +1009,19 @@ def fastapi_strompreis() -> list[float]:
     return elecprice
 
 
-class GesamtlastRequest(PydanticBaseModel):
+class TotalLoadRequest(PydanticBaseModel):
     year_energy: float
     measured_data: List[Dict[str, Any]]
     hours: int
 
 
-@app.post("/gesamtlast", tags=["prediction"])
-def fastapi_gesamtlast(request: GesamtlastRequest) -> list[float]:
+# Backward compatibility alias
+GesamtlastRequest = TotalLoadRequest
+
+
+@app.post("/total_load", tags=["prediction"])
+@app.post("/gesamtlast", tags=["prediction"], deprecated=True)  # Keep for backward compatibility
+def fastapi_total_load(request: TotalLoadRequest) -> list[float]:
     """Deprecated: Total Load Prediction with adjustment.
 
     Endpoint to handle total load prediction adjusted by latest measured data.
@@ -1095,8 +1101,11 @@ def fastapi_gesamtlast(request: GesamtlastRequest) -> list[float]:
     return prediction_list
 
 
-@app.get("/gesamtlast_simple", tags=["prediction"])
-def fastapi_gesamtlast_simple(year_energy: float) -> list[float]:
+@app.get("/total_load_simple", tags=["prediction"])
+@app.get(
+    "/gesamtlast_simple", tags=["prediction"], deprecated=True
+)  # Keep for backward compatibility
+def fastapi_total_load_simple(year_energy: float) -> list[float]:
     """Deprecated: Total Load Prediction.
 
     Endpoint to handle total load prediction.

--- a/src/akkudoktoreos/utils/visualize.py
+++ b/src/akkudoktoreos/utils/visualize.py
@@ -449,7 +449,7 @@ def prepare_visualize(
     report.create_line_chart_date(
         next_full_hour_date,
         [
-            parameters.ems.gesamtlast[start_hour:],
+            parameters.ems.total_load[start_hour:],
         ],
         title="Load Profile",
         # xlabel="Hours", # not enough space
@@ -459,7 +459,7 @@ def prepare_visualize(
     report.create_line_chart_date(
         next_full_hour_date,
         [
-            parameters.ems.pv_prognose_wh[start_hour:],
+            parameters.ems.pv_forecast_wh[start_hour:],
         ],
         title="PV Forecast",
         # xlabel="Hours", # not enough space
@@ -470,10 +470,10 @@ def prepare_visualize(
         next_full_hour_date,
         [
             np.full(
-                len(parameters.ems.gesamtlast) - start_hour,
-                parameters.ems.einspeiseverguetung_euro_pro_wh[start_hour:]
-                if isinstance(parameters.ems.einspeiseverguetung_euro_pro_wh, list)
-                else parameters.ems.einspeiseverguetung_euro_pro_wh,
+                len(parameters.ems.total_load) - start_hour,
+                parameters.ems.feed_in_tariff_per_wh[start_hour:]
+                if isinstance(parameters.ems.feed_in_tariff_per_wh, list)
+                else parameters.ems.feed_in_tariff_per_wh,
             )
         ],
         title="Remuneration",
@@ -534,7 +534,7 @@ def prepare_visualize(
     )
     report.create_line_chart_date(
         next_full_hour_date,  # start_date
-        [parameters.ems.strompreis_euro_pro_wh[start_hour:]],
+        [parameters.ems.electricity_price_per_wh[start_hour:]],
         # title="Electricity Price", # not enough space
         # xlabel="Date", # not enough space
         ylabel="Electricity Price (€/Wh)",

--- a/tests/test_class_ems.py
+++ b/tests/test_class_ems.py
@@ -227,6 +227,7 @@ def create_ems_instance(devices_eos, config_eos) -> EnergyManagement:
     # Initialize the energy management system with the respective parameters
     ems = get_ems()
     ems.set_parameters(
+        # Test using old field names for backward compatibility
         EnergyManagementParameters(
             pv_prognose_wh=pv_prognose_wh,
             strompreis_euro_pro_wh=strompreis_euro_pro_wh,

--- a/tests/test_class_ems_2.py
+++ b/tests/test_class_ems_2.py
@@ -130,6 +130,7 @@ def create_ems_instance(devices_eos, config_eos) -> EnergyManagement:
     # Initialize the energy management system with the respective parameters
     ems = get_ems()
     ems.set_parameters(
+        # Test using old field names for backward compatibility
         EnergyManagementParameters(
             pv_prognose_wh=pv_prognose_wh,
             strompreis_euro_pro_wh=strompreis_euro_pro_wh,


### PR DESCRIPTION
## Summary
 
This PR addresses issue #628 by introducing English field names to the EOS API while maintaining backward compatibility with existing German field names. It also removes currency-specific references to support internationalization.
 
## Changes
 
### English API Field Names
- Added English field names to `EnergyManagementParameters` and `SimulationResult` models
- Added English API endpoints: `/electricity_price`, `/total_load`, `/total_load_simple`
- German endpoints remain functional for backward compatibility
 
### Currency-Neutral Field Names
- Removed "euro" from field names (e.g., `electricity_price_euro_per_wh` → `electricity_price_per_wh`)
- Maintains compatibility with euro-suffixed names through aliases
 
## Backward Compatibility
 
No breaking changes. The API accepts:
1. Currency-neutral English names (preferred)
2. Euro-specific English names (backward compatible)
3. Original German names (legacy support)
 
## Example
 
```python
# All three approaches work:
 
# New (preferred)
params = EnergyManagementParameters(
    electricity_price_per_wh=[0.001, 0.002],
    feed_in_tariff_per_wh=0.00007,
    total_load=[50.0, 60.0]
)
 
# Backward compatible
params = EnergyManagementParameters(
    electricity_price_euro_per_wh=[0.001, 0.002],
    feed_in_tariff_euro_per_wh=0.00007,
    total_load=[50.0, 60.0]
)
 
# Legacy
params = EnergyManagementParameters(
    strompreis_euro_pro_wh=[0.001, 0.002],
    einspeiseverguetung_euro_pro_wh=0.00007,
    gesamtlast=[50.0, 60.0]
)
```
 
## Testing
 
- New English field names work correctly
- Currency-neutral field names function properly
- Backward compatibility maintained for all existing field names
- All existing tests pass without modification
 
Fixes #628
