### PR TITLE
fix: ensure EV charge rates settings available

### DIFF
--- a/docs/_generated/config.md
+++ b/docs/_generated/config.md
@@ -602,7 +602,7 @@ Properties:
 | max_charge_power_w | `Optional[float]` | `rw` | `5000` | Maximum charging power [W]. |
 | min_charge_power_w | `Optional[float]` | `rw` | `50` | Minimum charging power [W]. |
 | charge_rates | `Optional[list[float]]` | `rw` | `None` | Charge rates as factor of maximum charging power [0.00 ... 1.00]. None denotes all charge rates are available. |
-| min_soc_percentage | `int` | `rw` | `0` | Minimum state of charge (SOC) as percentage of capacity [%]. |
+| min_soc_percentage | `int` | `rw` | `0` | Minimum state of charge (SOC) as percentage of capacity [%]. This is the target SoC for charging |
 | max_soc_percentage | `int` | `rw` | `100` | Maximum state of charge (SOC) as percentage of capacity [%]. |
 | measurement_key_soc_factor | `str` | `ro` | `N/A` | Measurement key for the battery state of charge (SoC) as factor of total capacity [0.0 ... 1.0]. |
 | measurement_key_power_l1_w | `str` | `ro` | `N/A` | Measurement key for the L1 power the battery is charged or discharged with [W]. |

--- a/docs/akkudoktoreos/optimpost.md
+++ b/docs/akkudoktoreos/optimpost.md
@@ -77,6 +77,7 @@ passed to the request. You have to set the parameters even if given in the confi
         "device_id": "ev1",
         "capacity_wh": 60000,
         "charging_efficiency": 0.95,
+        "charge_rates": [0.0, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0],
         "discharging_efficiency": 1.0,
         "max_charge_power_w": 11040,
         "initial_soc_percentage": 54,

--- a/openapi.json
+++ b/openapi.json
@@ -2067,7 +2067,7 @@
             "maximum": 100.0,
             "minimum": 0.0,
             "title": "Min Soc Percentage",
-            "description": "Minimum state of charge (SOC) as percentage of capacity [%].",
+            "description": "Minimum state of charge (SOC) as percentage of capacity [%]. This is the target SoC for charging",
             "default": 0,
             "examples": [
               10
@@ -2208,7 +2208,7 @@
             "maximum": 100.0,
             "minimum": 0.0,
             "title": "Min Soc Percentage",
-            "description": "Minimum state of charge (SOC) as percentage of capacity [%].",
+            "description": "Minimum state of charge (SOC) as percentage of capacity [%]. This is the target SoC for charging",
             "default": 0,
             "examples": [
               10
@@ -3184,6 +3184,31 @@
             "title": "Max Soc Percentage",
             "description": "An integer representing the maximum state of charge (SOC) of the battery in percentage.",
             "default": 100
+          },
+          "charge_rates": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Charge Rates",
+            "description": "Charge rates as factor of maximum charging power [0.00 ... 1.00]. None denotes all charge rates are available.",
+            "examples": [
+              [
+                0.0,
+                0.25,
+                0.5,
+                0.75,
+                1.0
+              ],
+              null
+            ]
           }
         },
         "additionalProperties": false,

--- a/src/akkudoktoreos/devices/devices.py
+++ b/src/akkudoktoreos/devices/devices.py
@@ -71,7 +71,7 @@ class BatteriesCommonSettings(DevicesBaseSettings):
         default=0,
         ge=0,
         le=100,
-        description="Minimum state of charge (SOC) as percentage of capacity [%].",
+        description="Minimum state of charge (SOC) as percentage of capacity [%]. This is the target SoC for charging",
         examples=[10],
     )
 

--- a/src/akkudoktoreos/optimization/genetic/genetic.py
+++ b/src/akkudoktoreos/optimization/genetic/genetic.py
@@ -837,15 +837,33 @@ class GeneticOptimization(OptimizationBase):
             self.optimize_ev = (
                 parameters.eauto.min_soc_percentage - parameters.eauto.initial_soc_percentage >= 0
             )
-            try:
-                charge_rates = self.config.devices.electric_vehicles[0].charge_rates
-                if charge_rates is None:
-                    raise
-            except:
-                error_msg = "No charge rates provided for electric vehicle."
-                logger.exception(error_msg)
-                raise ValueError(error_msg)
-            self.ev_possible_charge_values = charge_rates
+            # electrical vehicle charge rates
+            if parameters.eauto.charge_rates is not None:
+                self.ev_possible_charge_values = parameters.eauto.charge_rates
+            elif (
+                self.config.devices.electric_vehicles
+                and self.config.devices.electric_vehicles[0]
+                and self.config.devices.electric_vehicles[0].charge_rates is not None
+            ):
+                self.ev_possible_charge_values = self.config.devices.electric_vehicles[
+                    0
+                ].charge_rates
+            else:
+                warning_msg = "No charge rates provided for electric vehicle - using default."
+                logger.warning(warning_msg)
+                self.ev_possible_charge_values = [
+                    0.0,
+                    0.1,
+                    0.2,
+                    0.3,
+                    0.4,
+                    0.5,
+                    0.6,
+                    0.7,
+                    0.8,
+                    0.9,
+                    1.0,
+                ]
         else:
             self.optimize_ev = False
 

--- a/src/akkudoktoreos/optimization/genetic/geneticdevices.py
+++ b/src/akkudoktoreos/optimization/genetic/geneticdevices.py
@@ -90,6 +90,11 @@ class ElectricVehicleParameters(BaseBatteryParameters):
     initial_soc_percentage: int = initial_soc_percentage_field(
         "An integer representing the current state of charge (SOC) of the battery in percentage."
     )
+    charge_rates: Optional[list[float]] = Field(
+        default=None,
+        description="Charge rates as factor of maximum charging power [0.00 ... 1.00]. None denotes all charge rates are available.",
+        examples=[[0.0, 0.25, 0.5, 0.75, 1.0], None],
+    )
 
 
 class HomeApplianceParameters(DeviceParameters):

--- a/src/akkudoktoreos/optimization/genetic/geneticparams.py
+++ b/src/akkudoktoreos/optimization/genetic/geneticparams.py
@@ -462,6 +462,7 @@ class GeneticOptimizationParameters(
                         capacity_wh=electric_vehicle_config.capacity_wh,
                         charging_efficiency=electric_vehicle_config.charging_efficiency,
                         discharging_efficiency=electric_vehicle_config.discharging_efficiency,
+                        charge_rates=electric_vehicle_config.charge_rates,
                         max_charge_power_w=electric_vehicle_config.max_charge_power_w,
                         min_soc_percentage=electric_vehicle_config.min_soc_percentage,
                         max_soc_percentage=electric_vehicle_config.max_soc_percentage,


### PR DESCRIPTION
Allow charge rates for electric vehicle to be provided by the POST optimize endpoint. Create a default value in case neither the parameters nor the configuration provide charge rates.

This is also to allow to migrate from 0.1.0 configuration format to actual one.