### PR TITLE
chore: development version v0.2.0+dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ docker-build:
 	@docker compose build --pull
 
 # Bump Akkudoktoreos version
-VERSION ?= 0.2.0
+VERSION ?= 0.2.0+dev
 NEW_VERSION ?= $(VERSION)+dev
 
 bump: pip-dev

--- a/docs/_generated/config.md
+++ b/docs/_generated/config.md
@@ -21,7 +21,7 @@ Properties:
 
 | Name | Environment Variable | Type | Read-Only | Default | Description |
 | ---- | -------------------- | ---- | --------- | ------- | ----------- |
-| version | `EOS_GENERAL__VERSION` | `str` | `rw` | `0.2.0` | Configuration file version. Used to check compatibility. |
+| version | `EOS_GENERAL__VERSION` | `str` | `rw` | `0.2.0+dev` | Configuration file version. Used to check compatibility. |
 | data_folder_path | `EOS_GENERAL__DATA_FOLDER_PATH` | `Optional[pathlib.Path]` | `rw` | `None` | Path to EOS data directory. |
 | data_output_subpath | `EOS_GENERAL__DATA_OUTPUT_SUBPATH` | `Optional[pathlib.Path]` | `rw` | `output` | Sub-path for the EOS output data directory. |
 | latitude | `EOS_GENERAL__LATITUDE` | `Optional[float]` | `rw` | `52.52` | Latitude in decimal degrees, between -90 and 90, north is positive (ISO 19115) (°) |
@@ -39,7 +39,7 @@ Properties:
 
    {
        "general": {
-           "version": "0.2.0",
+           "version": "0.2.0+dev",
            "data_folder_path": null,
            "data_output_subpath": "output",
            "latitude": 52.52,
@@ -55,7 +55,7 @@ Properties:
 
    {
        "general": {
-           "version": "0.2.0",
+           "version": "0.2.0+dev",
            "data_folder_path": null,
            "data_output_subpath": "output",
            "latitude": 52.52,
@@ -1780,7 +1780,7 @@ Validators:
 
    {
        "general": {
-           "version": "0.2.0",
+           "version": "0.2.0+dev",
            "data_folder_path": null,
            "data_output_subpath": "output",
            "latitude": 52.52,

--- a/docs/_generated/openapi.md
+++ b/docs/_generated/openapi.md
@@ -1,6 +1,6 @@
 # Akkudoktor-EOS
 
-**Version**: `v0.2.0`
+**Version**: `v0.2.0+dev`
 
 **Description**: This project provides a comprehensive solution for simulating and optimizing an energy system based on renewable energy sources. With a focus on photovoltaic (PV) systems, battery storage (batteries), load management (consumer requirements), heat pumps, electric vehicles, and consideration of electricity price data, this system enables forecasting and optimization of energy flow and costs over a specified period.
 

--- a/openapi.json
+++ b/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Akkudoktor-EOS",
     "description": "This project provides a comprehensive solution for simulating and optimizing an energy system based on renewable energy sources. With a focus on photovoltaic (PV) systems, battery storage (batteries), load management (consumer requirements), heat pumps, electric vehicles, and consideration of electricity price data, this system enables forecasting and optimization of energy flow and costs over a specified period.",
-    "version": "v0.2.0"
+    "version": "v0.2.0+dev"
   },
   "paths": {
     "/v1/admin/cache/clear": {
@@ -2406,7 +2406,7 @@
           "general": {
             "$ref": "#/components/schemas/GeneralSettings-Output",
             "default": {
-              "version": "0.2.0",
+              "version": "0.2.0+dev",
               "data_output_subpath": "output",
               "latitude": 52.52,
               "longitude": 13.405,
@@ -4062,7 +4062,7 @@
             "type": "string",
             "title": "Version",
             "description": "Configuration file version. Used to check compatibility.",
-            "default": "0.2.0"
+            "default": "0.2.0+dev"
           },
           "data_folder_path": {
             "anyOf": [
@@ -4136,7 +4136,7 @@
             "type": "string",
             "title": "Version",
             "description": "Configuration file version. Used to check compatibility.",
-            "default": "0.2.0"
+            "default": "0.2.0+dev"
           },
           "data_folder_path": {
             "anyOf": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akkudoktor-eos"
-version = "0.2.0"
+version = "0.2.0+dev"
 authors = [
   { name="Andreas Schmitz", email="author@example.com" },
 ]
@@ -111,7 +111,7 @@ ignore_missing_imports = true
 [tool.commitizen]
 name = "cz_conventional_commits"
 version_scheme = "semver"
-version = "0.2.0"            # <-- Set your current version heretag_format = "v$version"
+version = "0.2.0+dev"            # <-- Set your current version heretag_format = "v$version"
 
 # Files to automatically update when bumping version
 update_changelog_on_bump = true

--- a/src/akkudoktoreos/core/version.py
+++ b/src/akkudoktoreos/core/version.py
@@ -2,4 +2,4 @@
 
 # For development add `+dev` to previous release
 # For release omit `+dev`.
-__version__ = "0.2.0"
+__version__ = "0.2.0+dev"

--- a/src/akkudoktoreos/data/default.config.json
+++ b/src/akkudoktoreos/data/default.config.json
@@ -1,5 +1,5 @@
 {
   "general": {
-    "version": "0.2.0"
+    "version": "0.2.0+dev"
   }
 }


### PR DESCRIPTION
## Development version v0.2.0+dev

This pull request marks the repository as back in active development.

### Changes
- Set version to `v0.2.0+dev`

No changelog entry is needed.
