### PR TITLE
fix: openmeteo test

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@
 # the root directory (no add-on folder as usual).
 
 name: "Akkudoktor-EOS"
-version: "0.2.0.dev2603160842907888"
+version: "0.2.0.dev2603171142907888"
 slug: "eos"
 description: "Akkudoktor-EOS add-on"
 url: "https://github.com/Akkudoktor-EOS/EOS"

--- a/docs/_generated/openapi.md
+++ b/docs/_generated/openapi.md
@@ -1,6 +1,6 @@
 # Akkudoktor-EOS
 
-**Version**: `v0.2.0.dev2603160842907888`
+**Version**: `v0.2.0.dev2603171142907888`
 
 <!-- pyml disable line-length -->
 **Description**: This project provides a comprehensive solution for simulating and optimizing an energy system based on renewable energy sources. With a focus on photovoltaic (PV) systems, battery storage (batteries), load management (consumer requirements), heat pumps, electric vehicles, and consideration of electricity price data, this system enables forecasting and optimization of energy flow and costs over a specified period.

--- a/openapi.json
+++ b/openapi.json
@@ -8,7 +8,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "v0.2.0.dev2603160842907888"
+    "version": "v0.2.0.dev2603171142907888"
   },
   "paths": {
     "/v1/admin/cache/clear": {

--- a/tests/test_weatheropenmeteo.py
+++ b/tests/test_weatheropenmeteo.py
@@ -207,27 +207,58 @@ def test_openmeteo_unit_conversions(provider):
     assert pressure_mapping[2] == 0.01  # Conversion factor
 
 
+@pytest.mark.parametrize(
+    "start_offset_days, expected_keys, forbidden_keys",
+    [
+        # Future → forecast mode
+        (1, ["forecast_days"], ["start_date", "end_date", "models"]),
+        # Today (edge case, should still be forecast)
+        (0, ["forecast_days"], ["start_date", "end_date", "models"]),
+        # Past → historical mode
+        (-2, ["start_date", "end_date", "models"], ["forecast_days"]),
+    ],
+)
 @patch("requests.get")
-def test_forecast_days_calculation(mock_get, provider, sample_openmeteo_1_json):
-    """Test that forecast_days is correctly calculated."""
+def test_openmeteo_request_mode_selection(
+    mock_get,
+    provider,
+    sample_openmeteo_1_json,
+    start_offset_days,
+    expected_keys,
+    forbidden_keys,
+):
+    """Test that Open-Meteo request switches correctly between forecast and historical modes."""
+
+    # Mock response
     mock_response = Mock()
     mock_response.status_code = 200
     mock_response.json.return_value = sample_openmeteo_1_json
-    mock_response.content = json.dumps(sample_openmeteo_1_json)
+    mock_response.content = str(sample_openmeteo_1_json)
     mock_get.return_value = mock_response
 
-    ems_eos = get_ems()
+    # Set deterministic start time
+    now = to_datetime(in_timezone="Europe/Berlin")
+    start = now + pd.Timedelta(days=start_offset_days)
 
-    # Test with 3 days forecast
-    start = to_datetime(in_timezone="Europe/Berlin")
+    ems_eos = get_ems()
     ems_eos.set_start_datetime(start)
 
+    # Execute
     provider._request_forecast()
 
-    # Check that forecast_days was set correctly
-    call_args = mock_get.call_args
-    params = call_args[1]["params"]
-    assert params["forecast_days"]
+    # Inspect request params
+    params = mock_get.call_args[1]["params"]
+
+    # Assertions
+    for key in expected_keys:
+        assert key in params, f"Expected '{key}' in params but got {params}"
+
+    for key in forbidden_keys:
+        assert key not in params, f"Did not expect '{key}' in params but got {params}"
+
+    if "forecast_days" in params:
+        assert params["forecast_days"] >= 1
+        assert params["forecast_days"] <= 16
 
 
 # ------------------------------------------------


### PR DESCRIPTION
Make test more robust against time race conditions.

Failing test due to time race currently blocks #956 #955 #954.