### PR TITLE
fix: bump release workflow blocked by rules

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -45,54 +45,36 @@ jobs:
         run: |
           echo "Version contains 'dev'. Skipping release-related steps."
 
-      # --- Step 5: Update files and commit if necessary ---
-      - name: Update files and commit
-        id: commit_release
+      # --- Step 5: Tag release version ---
+      - name: Tag release version
+        id: tagging
         if: "!contains(steps.calc.outputs.version, 'dev')"
         run: |
           git config user.name "github-actions"
           git config user.email "actions@github.com"
-
-          # Files that contain the version string
-          UPDATE_FILES="config.yaml .env"
-
-          # Update versions
-          python scripts/update_version.py "${{ steps.calc.outputs.version }}" $UPDATE_FILES
-
-          # Commit changes if any
-          git add $UPDATE_FILES
-
-          if git diff --cached --quiet; then
-            echo "No files changed. Skipping commit."
-            echo "committed=false" >> "$GITHUB_OUTPUT"
-          else
-            git commit -m "chore: bump version to ${{ steps.calc.outputs.version }}"
-            git push
-            echo "committed=true" >> "$GITHUB_OUTPUT"
-          fi
-          # Always signal this is a release, regardless of whether files changed
-          echo "is_release=true" >> "$GITHUB_OUTPUT"
-
-      # --- Step 6: Create release tag ---
-      - name: Create release tag if it does not exist
-        id: tagging
-        if: steps.commit_release.outputs.is_release == 'true'
-        run: |
           TAG="v${{ steps.calc.outputs.version }}"
           if git rev-parse --verify "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists. Skipping tag creation."
+            echo "Tag $TAG already exists. Skipping."
+            echo "tagged=false" >> "$GITHUB_OUTPUT"
           else
             git tag -a "$TAG" -m "Release ${{ steps.calc.outputs.version }}"
             git push origin "$TAG"
+            echo "tagged=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # --- Step 7: Bump to development version ---
-      - name: Bump dev version
-        id: bump_dev
-        if: steps.commit_release.outputs.is_release == 'true'
+      # --- Step 6: Create PR to bump to dev version ---
+      - name: Bump dev version and create PR
+        if: "!contains(steps.calc.outputs.version, 'dev')"
         run: |
           git config user.name "github-actions"
           git config user.email "actions@github.com"
+          BRANCH="chore/bump-dev-version-${{ steps.calc.outputs.version }}"
+          # Skip if branch or PR already exists
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Branch $BRANCH already exists. Skipping."
+            exit 0
+          fi
+          git checkout -b "$BRANCH"
           VERSION_BASE=$(python scripts/bump_dev_version.py | tail -n1)
           if [ -z "$VERSION_BASE" ]; then
             echo "Error: bump_dev_version.py returned an empty version."
@@ -100,8 +82,15 @@ jobs:
           fi
           git add src/akkudoktoreos/core/version.py
           if git diff --cached --quiet; then
-            echo "version.py not changed. Skipping commit."
+            echo "version.py not changed. Skipping."
           else
             git commit -m "chore: bump dev version to ${VERSION_BASE}"
-            git push
+            git push origin "$BRANCH"
+            gh pr create \
+              --title "chore: bump dev version to ${VERSION_BASE}" \
+              --body "Automated dev version bump after release ${{ steps.calc.outputs.version }}." \
+              --base main \
+              --head "$BRANCH"
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/develop/release.md
+++ b/docs/develop/release.md
@@ -1,4 +1,5 @@
 % SPDX-License-Identifier: Apache-2.0
+
 (release-page)=
 
 # Release Process
@@ -13,8 +14,9 @@ and how to set a **development version** after the release.
 | 1    | Contributor | Prepare a release branch **in your fork** |
 | 2    | Contributor | Open a **Pull Request to upstream** (`Akkudoktor-EOS/EOS`) |
 | 3    | Maintainer  | Review and **merge the release PR** |
-| 4    | CI  | Create the **GitHub Release and tag** |
-| 5    | CI  | Set the **development version marker** via a follow-up PR |
+| 4    | CI          | Create the **GitHub Release and tag** |
+| 5    | CI          | Open a **Pull Request to set the development version marker** |
+| 6    | Maintainer  | Review and **merge the development version PR** |
 
 ## 🔄 Detailed Workflow
 
@@ -26,11 +28,10 @@ and how to set a **development version** after the release.
 git clone https://github.com/<your-username>/EOS
 cd EOS
 git remote add eos https://github.com/Akkudoktor-EOS/EOS
-
 git fetch eos
 git checkout main
 git pull eos main
-````
+```
 
 #### Create the release branch
 
@@ -101,10 +102,12 @@ chore: prepare release vX.Y.Z
 This pull request prepares release **vX.Y.Z**.
 
 ### Changes
+
 - Version bump
 - Changelog update
 
 ### Changelog Summary
+
 <!-- Copy key highlights from CHANGELOG.md here -->
 
 See `CHANGELOG.md` for full details.
@@ -127,14 +130,32 @@ See `CHANGELOG.md` for full details.
 ### 4️⃣ CI: Publish the GitHub Release
 
 The new release will automatically be published by the GitHub CI action.
+See `.github/workflows/bump-version.yml` for details.
 
-See `.github/workflwows/bump-version.yml`for details.
+### 5️⃣ CI: Open Pull Request for Development Version Marker
 
-### 5️⃣ CI: Prepare the Development Version Marker
+After tagging the release, the CI automatically opens a Pull Request to bump
+the version to the next development version marker `.dev`.
+See `.github/workflows/bump-version.yml` for details.
 
-The development version marker `.dev` will automatically be set by the GitHub CI action.
+**PR Title:**
 
-See `.github/workflwows/bump-version.yml`for details.
+```text
+chore: bump dev version to vX.Y+1.0.dev
+```
+
+### 6️⃣ Maintainer: Review and Merge the Development Version PR
+
+**Review Checklist:**
+
+- ✅ Only `src/akkudoktoreos/core/version.py` is modified
+- ✅ Version has `.dev` suffix
+- ✅ No unrelated changes are included
+
+**Merge Strategy:**
+
+- Prefer **Merge Commit** (or **Squash Merge**, per project preference)
+- Use commit message: `chore: bump dev version to vX.Y+1.0.dev`
 
 ## ✅ Quick Reference
 
@@ -144,4 +165,5 @@ See `.github/workflwows/bump-version.yml`for details.
 | **2. Open release PR** | Contributor | Submit release for review |
 | **3. Review & merge release PR** | Maintainer | Finalize changes into `main` |
 | **4. Publish GitHub Release** | CI | Create tag & notify users |
-| **5. Prepare development version branch** | CI | Set development marker |
+| **5. Open development version PR** | CI | Open PR to set development marker |
+| **6. Review & merge development version PR** | Maintainer | Merge `.dev` version into `main` |


### PR DESCRIPTION
GitHub actions are not allowed to create commits on the main branch. Instead create a pull request for bumping version to development version.