### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,8 @@
 name: Run Pytest on Pull Request
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Akkudoktor-EOS/EOS/security/code-scanning/3](https://github.com/Akkudoktor-EOS/EOS/security/code-scanning/3)

In general, the fix is to explicitly set a `permissions` block for the workflow or for the specific job, granting only the minimum required scopes. For a pure CI test workflow that only needs to read the code and upload artifacts, `contents: read` is normally sufficient; no write permissions are needed.

The best minimal fix here, without changing existing functionality, is to add a root-level `permissions` block (so it applies to all jobs) specifying `contents: read`. This documents the intended privileges and ensures the `GITHUB_TOKEN` cannot be used to modify repo contents even if org defaults are broad or change later. Concretely, in `.github/workflows/pytest.yml`, insert:

```yml
permissions:
  contents: read
```

between the `name:` and `on:` keys (lines 1–3). No additional imports, actions, or steps are needed; the rest of the workflow remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
