### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,6 +30,7 @@ jobs:
   # Build platform matrix excludes. if-conditional with matrix on job level is not
   # supported, see https://github.com/actions/runner/issues/1985
   platform-excludes:
+    permissions: {}
     runs-on: ubuntu-latest
     outputs:
       excludes: ${{ steps.excludes.outputs.matrix }}


### PR DESCRIPTION
Potential fix for [https://github.com/Akkudoktor-EOS/EOS/security/code-scanning/2](https://github.com/Akkudoktor-EOS/EOS/security/code-scanning/2)

To fix the problem, we should explicitly declare a `permissions` block for the `platform-excludes` job, instead of relying on inherited defaults. Since this job only runs a small shell script and does not need to read or write repository contents or interact with GitHub APIs, the least-privilege configuration is to disable the `GITHUB_TOKEN` entirely for this job using `permissions: {}` (YAML empty mapping). This keeps existing functionality intact while documenting and enforcing that the job does not require any token permissions.

Concretely:
- In `.github/workflows/docker-build.yml`, inside the `jobs.platform-excludes` definition, add a `permissions: {}` line between the job name and `runs-on: ubuntu-latest`.
- No imports or additional methods are needed; this is pure workflow configuration.
- The other jobs (`build`, `merge`, etc.) remain unchanged; the `build` job already has an explicit, appropriate `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
