### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,8 @@
 name: pre-commit
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Akkudoktor-EOS/EOS/security/code-scanning/1](https://github.com/Akkudoktor-EOS/EOS/security/code-scanning/1)

In general, the problem is fixed by explicitly defining a `permissions` block for the workflow or for the specific job, limiting the `GITHUB_TOKEN` to the least privileges required. For a pre-commit linting/check job that only reads the repository code, `contents: read` is typically sufficient.

The best fix here, without changing functionality, is to add a workflow-level `permissions` block just after the `name` (or before `on:`) that sets `contents: read`. This will apply the minimal necessary read-only permission to all jobs (there is only one job, `pre-commit`) and makes the workflow’s needs explicit. No other permissions (like `issues` or `pull-requests`) are required for running pre-commit checks, and no additional steps or configuration changes are needed.

Concretely, in `.github/workflows/pre-commit.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: pre-commit` line and the `on:` block. No imports, methods, or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
