### PR TITLE
Support a 15-minute optimization interval (genetic optimizer + native 15-min Tibber prices)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `PVForecastPVNode` — native 15-minute forecasts from the pvnode.com API.
   - `PVForecastForecastSolar` — forecasts from the free Forecast.Solar API.
   - `PVForecastSolcast` — forecasts from the Solcast rooftop-site API.
+- 15-minute optimization interval for the genetic optimizer. `optimization.interval`
+  now accepts 900 (15 min) in addition to the default 3600 (1 hour), letting the
+  optimizer schedule on a quarter-hour grid for 15-minute dynamic electricity
+  tariffs. Device power caps and the solution/plan serializers are slot-aware; the
+  default 3600 s interval keeps the previous hourly behaviour. The new sub-hourly PV
+  providers (pvnode, Forecast.Solar, Solcast) feed their native resolution straight
+  into the quarter-hour grid.
 
 ## 0.3.0 (2026-03-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   default 3600 s interval keeps the previous hourly behaviour. The new sub-hourly PV
   providers (pvnode, Forecast.Solar, Solcast) feed their native resolution straight
   into the quarter-hour grid.
+  - The Tibber electricity price provider now requests native 15-minute exchange prices
+    (`priceInfoRange(resolution: QUARTER_HOURLY)`) and stores them at their native
+    resolution, so both the hourly and the 15-minute optimizer are fed the correct
+    grid. The seasonal price extrapolation is resolution-agnostic and stays identical
+    at the default hourly resolution.
 
 ## 0.3.0 (2026-03-17)
 

--- a/docs/_generated/configoptimization.md
+++ b/docs/_generated/configoptimization.md
@@ -11,7 +11,7 @@
 | genetic | `EOS_OPTIMIZATION__GENETIC` | `GeneticCommonSettings` | `rw` | `required` | Genetic optimization algorithm configuration. |
 | horizon | | `int` | `ro` | `N/A` | Number of optimization steps. |
 | horizon_hours | `EOS_OPTIMIZATION__HORIZON_HOURS` | `int` | `rw` | `24` | The general time window within which the energy optimization goal shall be achieved [h]. Defaults to 24 hours. |
-| interval | `EOS_OPTIMIZATION__INTERVAL` | `int` | `rw` | `3600` | The optimization interval [sec]. Defaults to 3600 seconds (1 hour) |
+| interval | `EOS_OPTIMIZATION__INTERVAL` | `int` | `rw` | `3600` | The optimization interval (slot length) [sec]. The genetic optimizer supports 3600 (1 hour) and 900 (15 min); other values fall back to 3600. Defaults to 3600 seconds (1 hour). |
 | keys | | `list[str]` | `ro` | `N/A` | The keys of the solution. |
 :::
 <!-- pyml enable line-length -->

--- a/docs/akkudoktoreos/optimauto.md
+++ b/docs/akkudoktoreos/optimauto.md
@@ -139,17 +139,16 @@ The energy management can be run in three modes:
     Each device simulation run must ensure that all tasks or appliance cycles (e.g., running a
     dishwasher) are completed within the configured time windows.
 
-- **interval**: Defines the time step in seconds between control actions
-    (e.g. `3600` for one hour, `900` for 15 minutes).
+- **interval**: Defines the time step (slot length) in seconds between control actions.
+    The genetic algorithm supports `3600` (one hour, the default) and `900` (15 minutes);
+    any other value falls back to `3600`. The number of optimization slots is
+    `prediction.hours * (3600 / interval)`, and device power caps as well as the solution
+    and energy-management-plan serializers are slot-aware.
 
-:::{warning}
-**Current Limitation**
-
-At present, the `interval` setting is **not used** by the genetic algorithm. Instead:
-
-- The control interval is fixed to **1 hour**.
-
-Support for configurable intervals (e.g. 15-minute steps) may be added in a future release.
+:::{note}
+Use `900` together with a 15-minute electricity price source (for example a dynamic or
+exchange-priced tariff) to let the optimizer schedule on a quarter-hour grid. Keeping the
+default `3600` preserves the previous hourly behaviour.
 :::
 
 #### Genetic Algorithm Parameters

--- a/src/akkudoktoreos/devices/genetic/battery.py
+++ b/src/akkudoktoreos/devices/genetic/battery.py
@@ -12,9 +12,20 @@ from akkudoktoreos.optimization.genetic.geneticdevices import (
 class Battery:
     """Represents a battery device with methods to simulate energy charging and discharging."""
 
-    def __init__(self, parameters: BaseBatteryParameters, prediction_hours: int):
+    def __init__(
+        self,
+        parameters: BaseBatteryParameters,
+        prediction_hours: int,
+        slot_duration_h: float = 1.0,
+    ):
+        # `prediction_hours` is the number of optimization slots, not hours. At
+        # the default optimization interval of 3600 s, slot_duration_h is 1.0 and
+        # the slot count equals the hour count, so existing callers are
+        # unaffected. At 900 s (15 min) slot_duration_h is 0.25 and there are 4x
+        # as many slots, each able to move a quarter of the hourly energy.
         self.parameters = parameters
         self.prediction_hours = prediction_hours
+        self.slot_duration_h = slot_duration_h
         self._setup()
 
     def _setup(self) -> None:
@@ -137,8 +148,12 @@ class Battery:
         # Raw extractable energy above minimum SoC
         raw_available_wh = max(self.soc_wh - self.min_soc_wh, 0.0)
 
-        # Maximum raw discharge due to power limit
-        max_raw_wh = self.max_charge_power_w  # TODO rename to max_discharge_power_w
+        # Maximum raw discharge due to power limit, scaled to the slot duration.
+        # max_charge_power_w is a power [W]; energy movable in one slot is
+        # power x slot_duration_h.
+        max_raw_wh = (
+            self.max_charge_power_w * self.slot_duration_h
+        )  # TODO rename to max_discharge_power_w
 
         # Actual raw withdrawal (internal)
         raw_withdrawal_wh = min(raw_available_wh, max_raw_wh)
@@ -229,7 +244,9 @@ class Battery:
 
         # Provide fast (3x..5x) local read access (vs. self.xxx) for repetitive read access
         soc_wh_fast = self.soc_wh
-        max_charge_power_w_fast = self.max_charge_power_w
+        # Scale the power cap [W] to a per-slot energy cap [Wh] (W x slot hours).
+        # At slot_duration_h=1.0 (hourly) this equals the legacy power value.
+        max_charge_per_slot_wh_fast = self.max_charge_power_w * self.slot_duration_h
         charging_efficiency_fast = self.charging_efficiency
 
         # Decide mode & determine raw_request_wh and raw_charge_wh
@@ -237,13 +254,13 @@ class Battery:
             raw_request_wh = wh
             raw_charge_wh = max(self.max_soc_wh - soc_wh_fast, 0.0) / charging_efficiency_fast
         elif wh is None and charge_factor > 0.0:  # mode 2
-            raw_request_wh = max_charge_power_w_fast * charge_factor
+            raw_request_wh = max_charge_per_slot_wh_fast * charge_factor
             raw_charge_wh = max(self.max_soc_wh - soc_wh_fast, 0.0) / charging_efficiency_fast
             if raw_request_wh > raw_charge_wh:
                 # Use a lower charge factor
                 lower_charge_factors = self._lower_charge_rates_desc(charge_factor)
                 for charge_factor in lower_charge_factors:
-                    raw_request_wh = max_charge_power_w_fast * charge_factor
+                    raw_request_wh = max_charge_per_slot_wh_fast * charge_factor
                     if raw_request_wh <= raw_charge_wh:
                         self.charge_array[hour] = charge_factor
                         break
@@ -258,7 +275,7 @@ class Battery:
             )
 
         # Remaining capacity
-        max_raw_wh = min(raw_charge_wh, max_charge_power_w_fast)
+        max_raw_wh = min(raw_charge_wh, max_charge_per_slot_wh_fast)
 
         # Actual raw intake
         raw_input_wh = raw_request_wh if raw_request_wh < max_raw_wh else max_raw_wh

--- a/src/akkudoktoreos/devices/genetic/homeappliance.py
+++ b/src/akkudoktoreos/devices/genetic/homeappliance.py
@@ -11,9 +11,15 @@ class HomeAppliance:
         parameters: HomeApplianceParameters,
         optimization_hours: int,
         prediction_hours: int,
+        slot_duration_h: float = 1.0,
     ):
+        # slot_duration_h is a forward-compatibility hook. Full sub-hourly home
+        # appliance scheduling additionally requires converting the start hour to
+        # a slot index and the duration to a slot count; the default of 1.0 keeps
+        # the hourly behaviour for the default optimization interval of 3600 s.
         self.parameters: HomeApplianceParameters = parameters
         self.prediction_hours = prediction_hours
+        self.slot_duration_h = slot_duration_h
         self._setup()
 
     def _setup(self) -> None:

--- a/src/akkudoktoreos/devices/genetic/inverter.py
+++ b/src/akkudoktoreos/devices/genetic/inverter.py
@@ -12,9 +12,14 @@ class Inverter:
         self,
         parameters: InverterParameters,
         battery: Optional[Battery] = None,
+        slot_duration_h: float = 1.0,
     ):
+        # slot_duration_h scales the per-slot energy cap (max_power_wh). It
+        # defaults to 1.0, which keeps the hourly behaviour for the default
+        # optimization interval of 3600 s.
         self.parameters: InverterParameters = parameters
         self.battery: Optional[Battery] = battery
+        self.slot_duration_h: float = slot_duration_h
         self._setup()
 
     def _setup(self) -> None:
@@ -23,11 +28,16 @@ class Inverter:
             logger.error(error_msg)
             raise ValueError(error_msg)
         self.self_consumption_predictor = get_eos_load_interpolator()
+        # max_power_wh is supplied as a power [W] that the legacy hourly code
+        # treats as Wh-per-hour. Scale it to the actual slot length so a 15-min
+        # slot can move at most a quarter of that energy.
         self.max_power_wh = (
-            self.parameters.max_power_wh
-        )  # Maximum power that the inverter can handle
+            self.parameters.max_power_wh * self.slot_duration_h
+        )  # Maximum energy the inverter can move in one optimization slot
         self.dc_to_ac_efficiency = self.parameters.dc_to_ac_efficiency
         self.ac_to_dc_efficiency = self.parameters.ac_to_dc_efficiency
+        # max_ac_charge_power_w stays in Watts. It feeds a dimensionless,
+        # slot-agnostic power-ratio cap in genetic.py simulate().
         self.max_ac_charge_power_w = self.parameters.max_ac_charge_power_w
 
     def process_energy(

--- a/src/akkudoktoreos/optimization/genetic/genetic.py
+++ b/src/akkudoktoreos/optimization/genetic/genetic.py
@@ -430,6 +430,45 @@ class GeneticSimulation(PydanticBaseModel):
 class GeneticOptimization(OptimizationBase):
     """GENETIC algorithm to solve energy optimization."""
 
+    # Slot-math helpers — single source of truth for the optimization grid.
+    # At the default optimization interval of 3600 s, slot_duration_h is 1.0 and
+    # total_slots equals prediction.hours, so the established hourly behaviour is
+    # preserved. At 900 s (15 min) slot_duration_h is 0.25 and there are 4x as
+    # many slots.
+    @property
+    def slot_duration_h(self) -> float:
+        """Length of one optimization slot in hours (1.0 hourly, 0.25 at 15 min)."""
+        interval = self.config.optimization.interval or 3600
+        return interval / 3600
+
+    @property
+    def slots_per_hour(self) -> int:
+        """Number of optimization slots per hour (1 hourly, 4 at 15 min)."""
+        interval = self.config.optimization.interval or 3600
+        return 3600 // interval
+
+    @property
+    def total_slots(self) -> int:
+        """Total number of optimization slots = prediction.hours * slots_per_hour."""
+        # Read prediction.hours directly to avoid recursing through total_slots.
+        return int(self.config.prediction.hours * self.slots_per_hour)
+
+    def _start_day_slot(self) -> int:
+        """Slot index of ems.start_datetime counted from the start day's midnight.
+
+        simulate()/evaluate() use the simulation start position as a slot index
+        into the prediction/charge arrays. Those arrays begin at the midnight of
+        ``ems.start_datetime`` (geneticparams sets ``start_datetime.set(hour=0)``),
+        so the index is computed from the same datetime — no timezone conversion —
+        keeping it consistent with how the arrays are built. At interval=3600 s
+        slots_per_hour == 1 and minute // 60 == 0, so this reduces to
+        ``start_datetime.hour`` (the previous hourly behaviour).
+        """
+        sd = self.ems.start_datetime
+        sph = self.slots_per_hour
+        slot_minutes = max(1, 60 // sph)
+        return sd.hour * sph + sd.minute // slot_minutes
+
     def __init__(
         self,
         verbose: bool = False,
@@ -437,8 +476,11 @@ class GeneticOptimization(OptimizationBase):
     ):
         """Initialize the optimization problem with the required parameters."""
         self.opti_param: dict[str, Any] = {}
-        self.fixed_eauto_hours = (
-            self.config.prediction.hours - self.config.optimization.horizon_hours
+        # Number of slots at the tail of the optimization window where EV
+        # charging is fixed to 0. Slot-counted so 15-min runs reserve the right
+        # tail length (at interval=3600 s this equals prediction.hours - horizon).
+        self.fixed_eauto_hours = self.total_slots - (
+            self.config.optimization.horizon_hours * self.slots_per_hour
         )
         self.ev_possible_charge_values: list[float] = [1.0]
         # Separate charge-level list for battery AC charging (independent of EV rates).
@@ -515,25 +557,21 @@ class GeneticOptimization(OptimizationBase):
             total_states = 3 * len_bat
 
         # 1. Mutating the charge_discharge part
-        charge_discharge_part = individual[: self.config.prediction.hours]
+        charge_discharge_part = individual[: self.total_slots]
         (charge_discharge_mutated,) = self.toolbox.mutate_charge_discharge(charge_discharge_part)
 
         # Instead of a fixed clamping to 0..8 or 0..6 dynamically:
         charge_discharge_mutated = np.clip(charge_discharge_mutated, 0, total_states - 1)
-        individual[: self.config.prediction.hours] = charge_discharge_mutated
+        individual[: self.total_slots] = charge_discharge_mutated
 
         # 2. Mutating the EV charge part, if active
         if self.optimize_ev:
-            ev_charge_part = individual[
-                self.config.prediction.hours : self.config.prediction.hours * 2
-            ]
+            ev_charge_part = individual[self.total_slots : self.total_slots * 2]
             (ev_charge_part_mutated,) = self.toolbox.mutate_ev_charge_index(ev_charge_part)
-            ev_charge_part_mutated[self.config.prediction.hours - self.fixed_eauto_hours :] = [
+            ev_charge_part_mutated[self.total_slots - self.fixed_eauto_hours :] = [
                 0
             ] * self.fixed_eauto_hours
-            individual[self.config.prediction.hours : self.config.prediction.hours * 2] = (
-                ev_charge_part_mutated
-            )
+            individual[self.total_slots : self.total_slots * 2] = ev_charge_part_mutated
 
         # 3. Mutating the appliance start time, if applicable
         if self.opti_param["home_appliance"] > 0:
@@ -547,13 +585,13 @@ class GeneticOptimization(OptimizationBase):
     def create_individual(self) -> list[int]:
         # Start with discharge states for the individual
         individual_components = [
-            self.toolbox.attr_discharge_state() for _ in range(self.config.prediction.hours)
+            self.toolbox.attr_discharge_state() for _ in range(self.total_slots)
         ]
 
         # Add EV charge index values if optimize_ev is True
         if self.optimize_ev:
             individual_components += [
-                self.toolbox.attr_ev_charge_index() for _ in range(self.config.prediction.hours)
+                self.toolbox.attr_ev_charge_index() for _ in range(self.total_slots)
             ]
 
         # Add the start time of the household appliance if it's being optimized
@@ -586,7 +624,7 @@ class GeneticOptimization(OptimizationBase):
             individual.extend(eautocharge_hours_index.tolist())
         elif self.optimize_ev:
             # Falls optimize_ev aktiv ist, aber keine EV-Daten vorhanden sind, fügen wir Nullen hinzu
-            individual.extend([0] * self.config.prediction.hours)
+            individual.extend([0] * self.total_slots)
 
         # Add dishwasher start time if applicable
         if self.opti_param.get("home_appliance", 0) > 0 and washingstart_int is not None:
@@ -608,13 +646,13 @@ class GeneticOptimization(OptimizationBase):
         3. Dishwasher start time (integer if applicable).
         """
         # Discharge hours as a NumPy array of ints
-        discharge_hours_bin = np.array(individual[: self.config.prediction.hours], dtype=int)
+        discharge_hours_bin = np.array(individual[: self.total_slots], dtype=int)
 
         # EV charge hours as a NumPy array of ints (if optimize_ev is True)
         eautocharge_hours_index = (
             # append ev charging states to individual
             np.array(
-                individual[self.config.prediction.hours : self.config.prediction.hours * 2],
+                individual[self.total_slots : self.total_slots * 2],
                 dtype=int,
             )
             if self.optimize_ev
@@ -720,7 +758,7 @@ class GeneticOptimization(OptimizationBase):
         if self.optimize_dc_charge:
             self.simulation.dc_charge_hours = dc_charge_hours
         else:
-            self.simulation.dc_charge_hours = np.full(self.config.prediction.hours, 1)
+            self.simulation.dc_charge_hours = np.full(self.total_slots, 1)
         self.simulation.ac_charge_hours = ac_charge_hours
 
         if eautocharge_hours_index is not None:
@@ -732,10 +770,12 @@ class GeneticOptimization(OptimizationBase):
             self.simulation.ev_charge_hours = eautocharge_hours_float
         else:
             # discharge is set to 0 by default
-            self.simulation.ev_charge_hours = np.full(self.config.prediction.hours, 0)
+            self.simulation.ev_charge_hours = np.full(self.total_slots, 0)
 
-        # Do the simulation and return result.
-        return self.simulation.simulate(self.ems.start_datetime.hour)
+        # Do the simulation and return result. simulate()'s argument is a slot
+        # index into the prediction/charge arrays, not an hour-of-day, so pass
+        # the start_day_slot to keep sub-hourly runs aligned.
+        return self.simulation.simulate(self._start_day_slot())
 
     def evaluate(
         self,
@@ -1084,6 +1124,10 @@ class GeneticOptimization(OptimizationBase):
             raise ValueError(
                 f"Start hour not synced. EMS {self.ems.start_datetime.hour} vs. GENETIC {start_hour}."
             )
+        # start_hour stays the hour-of-day for the appliance-start gene bounds
+        # (0..23). Everything that indexes the slot arrays (the simulate offset
+        # and evaluate's break-even loop) uses the slot index instead.
+        start_slot = self._start_day_slot()
 
         # Set the number of generations
         generations = ngen
@@ -1094,28 +1138,43 @@ class GeneticOptimization(OptimizationBase):
                 generations = 400
                 logger.error("Generations not configured. Using {}.", generations)
 
-        einspeiseverguetung_euro_pro_wh = np.full(
-            self.config.prediction.hours, parameters.ems.einspeiseverguetung_euro_pro_wh
+        # The feed-in tariff may be a scalar or an hourly (prediction.hours)
+        # series. A scalar fills the whole slot grid; a series is upsampled by
+        # repeating each value slots_per_hour times. At interval=3600 s
+        # slots_per_hour == 1, so both reduce to the previous np.full behaviour.
+        einspeiseverguetung_param = np.asarray(
+            parameters.ems.einspeiseverguetung_euro_pro_wh, dtype=float
         )
+        if einspeiseverguetung_param.ndim == 0:
+            einspeiseverguetung_euro_pro_wh = np.full(
+                self.total_slots, float(einspeiseverguetung_param)
+            )
+        else:
+            einspeiseverguetung_euro_pro_wh = np.repeat(
+                einspeiseverguetung_param, self.slots_per_hour
+            )[: self.total_slots]
 
         self.simulation.reset()
 
-        # Initialize PV and EV batteries
+        # Initialize PV and EV batteries. slot_duration_h lets the Battery scale
+        # its power caps (max_charge_power_w) to a per-slot energy cap.
         akku: Optional[Battery] = None
         if parameters.pv_akku:
             akku = Battery(
                 parameters.pv_akku,
-                prediction_hours=self.config.prediction.hours,
+                prediction_hours=self.total_slots,
+                slot_duration_h=self.slot_duration_h,
             )
-            akku.set_charge_per_hour(np.full(self.config.prediction.hours, 0))
+            akku.set_charge_per_hour(np.full(self.total_slots, 0))
 
         eauto: Optional[Battery] = None
         if parameters.eauto:
             eauto = Battery(
                 parameters.eauto,
-                prediction_hours=self.config.prediction.hours,
+                prediction_hours=self.total_slots,
+                slot_duration_h=self.slot_duration_h,
             )
-            eauto.set_charge_per_hour(np.full(self.config.prediction.hours, 1))
+            eauto.set_charge_per_hour(np.full(self.total_slots, 1))
             self.optimize_ev = (
                 parameters.eauto.min_soc_percentage > parameters.eauto.initial_soc_percentage
             )
@@ -1173,35 +1232,40 @@ class GeneticOptimization(OptimizationBase):
             HomeAppliance(
                 parameters=parameters.dishwasher,
                 optimization_hours=self.config.optimization.horizon_hours,
-                prediction_hours=self.config.prediction.hours,
+                prediction_hours=self.total_slots,
+                slot_duration_h=self.slot_duration_h,
             )
             if parameters.dishwasher is not None
             else None
         )
 
-        # Initialize the inverter and energy management system
+        # Initialize the inverter and energy management system. slot_duration_h
+        # lets the Inverter scale max_power_wh to a per-slot energy cap.
         inverter: Optional[Inverter] = None
         if parameters.inverter:
             inverter = Inverter(
                 parameters.inverter,
                 battery=akku,
+                slot_duration_h=self.slot_duration_h,
             )
 
         # Prepare device simulation
         self.simulation.prepare(
             parameters=parameters.ems,
             optimization_hours=self.config.optimization.horizon_hours,
-            prediction_hours=self.config.prediction.hours,
+            prediction_hours=self.total_slots,
             inverter=inverter,  # battery is part of inverter
             ev=eauto,
             home_appliance=dishwasher,
         )
 
-        # Setup the DEAP environment and optimization process
+        # Setup the DEAP environment and optimization process. setup_deap gets
+        # the hour-of-day (appliance gene bounds); evaluate gets the slot index
+        # (its break-even loop walks the slot arrays from "now").
         self.setup_deap_environment({"home_appliance": 1 if dishwasher else 0}, start_hour)
         self.toolbox.register(
             "evaluate",
-            lambda ind: self.evaluate(ind, parameters, start_hour, worst_case),
+            lambda ind: self.evaluate(ind, parameters, start_slot, worst_case),
         )
 
         start_time = time.time()

--- a/src/akkudoktoreos/optimization/genetic/geneticparams.py
+++ b/src/akkudoktoreos/optimization/genetic/geneticparams.py
@@ -194,9 +194,17 @@ class GeneticOptimizationParameters(
         if cls.config.optimization.interval is None:
             logger.info("Optimization interval unknown - defaulting to 3600 seconds.")
             cls.config.optimization.interval = 3600
-        if cls.config.optimization.interval != 3600:
-            logger.info(
-                "Optimization interval '{}' seconds not supported - forced to 3600 seconds."
+        # The genetic optimizer runs on a fixed slot grid whose length is
+        # prediction.hours * (3600 / interval). 900 s (15 min) enables a
+        # quarter-hour grid for 15-minute electricity tariffs; the default
+        # 3600 s keeps the established hourly resolution. Other values fall back
+        # to 3600 s.
+        allowed_intervals = (3600, 900)
+        if cls.config.optimization.interval not in allowed_intervals:
+            logger.warning(
+                "Optimization interval {} seconds not in {} - forcing 3600 seconds.",
+                cls.config.optimization.interval,
+                allowed_intervals,
             )
             cls.config.optimization.interval = 3600
         # Check genetic algorithm definitions
@@ -306,12 +314,18 @@ class GeneticOptimizationParameters(
                 # Retry
                 continue
             try:
-                loadforecast_power_w = cls.prediction.key_to_array(
-                    key="loadforecast_power_w",
-                    start_datetime=parameter_start_datetime,
-                    end_datetime=parameter_end_datetime,
-                    interval=interval,
-                    fill_method="ffill",
+                # Load is a power series [W] that the genetic optimizer consumes
+                # as Wh-per-slot. Scale by interval/3600 (mirrors the PV forecast
+                # above) so a 15-min slot sees a quarter of the hourly energy.
+                loadforecast_power_w = (
+                    cls.prediction.key_to_array(
+                        key="loadforecast_power_w",
+                        start_datetime=parameter_start_datetime,
+                        end_datetime=parameter_end_datetime,
+                        interval=interval,
+                        fill_method="ffill",
+                    )
+                    * power_to_energy_per_interval_factor
                 ).tolist()
             except:
                 logger.info(

--- a/src/akkudoktoreos/optimization/genetic/geneticsolution.py
+++ b/src/akkudoktoreos/optimization/genetic/geneticsolution.py
@@ -357,20 +357,28 @@ class GeneticSolution(ConfigMixin, GeneticParametersBaseModel):
         - GRID_SUPPORT_IMPORT: ac_charge  > 0 and discharge_allowed == 0 or 1
         """
         start_datetime = get_ems().start_datetime
-        start_day_hour = start_datetime.in_timezone(self.config.general.timezone).hour
-        interval_hours = 1
-        power_to_energy_per_interval_factor = 1.0
+        # The genetic core emits total_slots = prediction.hours * slots_per_hour
+        # entries indexed by slot (slot 0 == 00:00 local). Index this serializer
+        # by slot too. At the default interval of 3600 s slots_per_hour == 1 and
+        # this is the established hourly behaviour.
+        interval_s = int(self.config.optimization.interval or 3600)
+        slots_per_hour = max(1, 3600 // interval_s)
+        slot_minutes = max(1, interval_s // 60)
+        start_local = start_datetime.in_timezone(self.config.general.timezone)
+        start_day_slot = start_local.hour * slots_per_hour + start_local.minute // slot_minutes
+        # power [W] -> energy per slot [Wh]: multiply by the slot duration in hours.
+        power_to_energy_per_interval_factor = interval_s / 3600.0
 
         # --- Create index based on list length and interval ---
         # Ensure we only use the minimum of results and commands if differing
-        periods = min(len(self.result.Kosten_Euro_pro_Stunde), len(self.ac_charge) - start_day_hour)
+        periods = min(len(self.result.Kosten_Euro_pro_Stunde), len(self.ac_charge) - start_day_slot)
         time_index = pd.date_range(
             start=start_datetime,
             periods=periods,
-            freq=f"{interval_hours}h",
+            freq=f"{interval_s}s",
         )
         n_points = len(time_index)
-        end_datetime = start_datetime.add(hours=n_points)
+        end_datetime = start_datetime.add(seconds=interval_s * n_points)
 
         # Fill solution into dataframe with correct column names
         # - load_energy_wh: Load of all energy consumers in wh"
@@ -386,7 +394,7 @@ class GeneticSolution(ConfigMixin, GeneticParametersBaseModel):
         solution = pd.DataFrame(
             {
                 "date_time": time_index,
-                # result starts at start_day_hour
+                # result starts at start_day_slot
                 "load_energy_wh": self.result.Last_Wh_pro_Stunde[:n_points],
                 "grid_feedin_energy_wh": self.result.Netzeinspeisung_Wh_pro_Stunde[:n_points],
                 "grid_consumption_energy_wh": self.result.Netzbezug_Wh_pro_Stunde[:n_points],
@@ -401,7 +409,7 @@ class GeneticSolution(ConfigMixin, GeneticParametersBaseModel):
         battery_device_id = self._battery_device_id()
         solution[f"{battery_device_id}_soc_factor"] = [
             v / 100
-            for v in self.result.akku_soc_pro_stunde[:n_points]  # result starts at start_day_hour
+            for v in self.result.akku_soc_pro_stunde[:n_points]  # result starts at start_day_slot
         ]
         operation: dict[str, list[float]] = {
             "genetic_ac_charge_factor": [],
@@ -410,9 +418,9 @@ class GeneticSolution(ConfigMixin, GeneticParametersBaseModel):
         }
         # ac_charge, dc_charge, discharge_allowed start at hour 0 of start day
         for hour_idx, rate in enumerate(self.ac_charge):
-            if hour_idx < start_day_hour:
+            if hour_idx < start_day_slot:
                 continue
-            if hour_idx >= start_day_hour + n_points:
+            if hour_idx >= start_day_slot + n_points:
                 break
             ac_charge_hour = self.ac_charge[hour_idx]
             dc_charge_hour = self.dc_charge[hour_idx]
@@ -425,7 +433,7 @@ class GeneticSolution(ConfigMixin, GeneticParametersBaseModel):
 
             # SOC-clamped effective values — what can physically be executed at
             # this hour given the expected battery state of charge.
-            result_idx = hour_idx - start_day_hour
+            result_idx = hour_idx - start_day_slot
             soc_h_pct = (
                 self.result.akku_soc_pro_stunde[result_idx]
                 if result_idx < len(self.result.akku_soc_pro_stunde)
@@ -486,9 +494,9 @@ class GeneticSolution(ConfigMixin, GeneticParametersBaseModel):
                     "genetic_ev_charge_factor": [],
                 }
                 for hour_idx, rate in enumerate(self.eautocharge_hours_float):
-                    if hour_idx < start_day_hour:
+                    if hour_idx < start_day_slot:
                         continue
-                    if hour_idx >= start_day_hour + n_points:
+                    if hour_idx >= start_day_slot + n_points:
                         break
                     operation["genetic_ev_charge_factor"].append(rate)
                     operation_mode, operation_mode_factor = self._battery_operation_from_solution(
@@ -518,7 +526,7 @@ class GeneticSolution(ConfigMixin, GeneticParametersBaseModel):
             # Use config and not self.washingstart as washingstart may be None (no start)
             # even if configured to be started.
             homeappliance_device_id = self._homeappliance_device_id()
-            # result starts at start_day_hour
+            # result starts at start_day_slot
             solution[f"{homeappliance_device_id}_energy_wh"] = (
                 self.result.Home_appliance_wh_per_hour[:n_points]
             )
@@ -616,7 +624,7 @@ class GeneticSolution(ConfigMixin, GeneticParametersBaseModel):
                     key=pred_key,
                     start_datetime=start_datetime,
                     end_datetime=end_datetime,
-                    interval=to_duration(f"{interval_hours} hours"),
+                    interval=to_duration(f"{interval_s} seconds"),
                     fill_method=pred_fill_method,
                 )
                 # 'key_to_array()' creates None values array if no data records are available.
@@ -644,7 +652,13 @@ class GeneticSolution(ConfigMixin, GeneticParametersBaseModel):
     def energy_management_plan(self) -> EnergyManagementPlan:
         """Provide the genetic solution as an energy management plan."""
         start_datetime = get_ems().start_datetime
-        start_day_hour = start_datetime.in_timezone(self.config.general.timezone).hour
+        # Index by slot, not hour (mirrors optimization_solution). At the default
+        # interval of 3600 s this reduces to the start hour-of-day.
+        interval_s = int(self.config.optimization.interval or 3600)
+        slots_per_hour = max(1, 3600 // interval_s)
+        slot_minutes = max(1, interval_s // 60)
+        start_local = start_datetime.in_timezone(self.config.general.timezone)
+        start_day_slot = start_local.hour * slots_per_hour + start_local.minute // slot_minutes
         plan = EnergyManagementPlan(
             id=f"plan-genetic@{to_datetime(as_string=True)}",
             generated_at=to_datetime(),
@@ -657,15 +671,15 @@ class GeneticSolution(ConfigMixin, GeneticParametersBaseModel):
         last_operation_mode_factor: Optional[float] = None
         resource_id = self._battery_device_id()
         # ac_charge, dc_charge, discharge_allowed start at hour 0 of start day
-        logger.debug("BAT: {} - {}", resource_id, self.ac_charge[start_day_hour:])
+        logger.debug("BAT: {} - {}", resource_id, self.ac_charge[start_day_slot:])
         for hour_idx, rate in enumerate(self.ac_charge):
-            if hour_idx < start_day_hour:
+            if hour_idx < start_day_slot:
                 continue
             # Derive SOC-clamped effective factors so that FRBCInstruction
             # operation_mode_factor reflects what can physically be executed,
             # while the raw genetic gene values are preserved in the solution
             # dataframe (genetic_*_factor columns).
-            result_idx = hour_idx - start_day_hour
+            result_idx = hour_idx - start_day_slot
             soc_h_pct = (
                 self.result.akku_soc_pro_stunde[result_idx]
                 if result_idx < len(self.result.akku_soc_pro_stunde)
@@ -688,7 +702,7 @@ class GeneticSolution(ConfigMixin, GeneticParametersBaseModel):
                 continue
             last_operation_mode = operation_mode
             last_operation_mode_factor = operation_mode_factor
-            execution_time = start_datetime.add(hours=hour_idx - start_day_hour)
+            execution_time = start_datetime.add(seconds=interval_s * (hour_idx - start_day_slot))
             plan.add_instruction(
                 FRBCInstruction(
                     resource_id=resource_id,
@@ -719,10 +733,10 @@ class GeneticSolution(ConfigMixin, GeneticParametersBaseModel):
                 last_operation_mode = None
                 last_operation_mode_factor = None
                 logger.debug(
-                    "EV: {} - {}", resource_id, self.eautocharge_hours_float[start_day_hour:]
+                    "EV: {} - {}", resource_id, self.eautocharge_hours_float[start_day_slot:]
                 )
                 for hour_idx, rate in enumerate(self.eautocharge_hours_float):
-                    if hour_idx < start_day_hour:
+                    if hour_idx < start_day_slot:
                         continue
                     operation_mode, operation_mode_factor = self._battery_operation_from_solution(
                         rate, 0.0, False
@@ -735,7 +749,9 @@ class GeneticSolution(ConfigMixin, GeneticParametersBaseModel):
                         continue
                     last_operation_mode = operation_mode
                     last_operation_mode_factor = operation_mode_factor
-                    execution_time = start_datetime.add(hours=hour_idx - start_day_hour)
+                    execution_time = start_datetime.add(
+                        seconds=interval_s * (hour_idx - start_day_slot)
+                    )
                     plan.add_instruction(
                         FRBCInstruction(
                             resource_id=resource_id,
@@ -764,7 +780,7 @@ class GeneticSolution(ConfigMixin, GeneticParametersBaseModel):
                     else:
                         operation_mode = ApplianceOperationMode.OFF  # type: ignore[assignment]
                     operation_mode_factor = 1.0
-                    execution_time = start_datetime.add(hours=hours)
+                    execution_time = start_datetime.add(seconds=interval_s * hours)
                     plan.add_instruction(
                         DDBCInstruction(
                             resource_id=resource_id,

--- a/src/akkudoktoreos/optimization/optimization.py
+++ b/src/akkudoktoreos/optimization/optimization.py
@@ -72,7 +72,11 @@ class OptimizationCommonSettings(SettingsBaseModel):
         ge=15 * 60,
         le=60 * 60,
         json_schema_extra={
-            "description": "The optimization interval [sec]. Defaults to 3600 seconds (1 hour)",
+            "description": (
+                "The optimization interval (slot length) [sec]. The genetic "
+                "optimizer supports 3600 (1 hour) and 900 (15 min); other values "
+                "fall back to 3600. Defaults to 3600 seconds (1 hour)."
+            ),
             "examples": [60 * 60, 15 * 60],
         },
     )

--- a/src/akkudoktoreos/prediction/elecpricetibber.py
+++ b/src/akkudoktoreos/prediction/elecpricetibber.py
@@ -34,7 +34,7 @@ query TibberPriceInfo {
             total
           }
         }
-        priceInfoRange(resolution: HOURLY, last: 840) {
+        priceInfoRange(resolution: QUARTER_HOURLY, last: 960) {
           nodes {
             startsAt
             total
@@ -245,13 +245,36 @@ class ElecPriceTibber(ElecPriceProvider):
 
         return series_data.sort_index()
 
-    def _hourly_series(self, series: pd.Series) -> pd.Series:
-        """Normalize Tibber prices to hourly values for EOS optimization."""
+    def _normalize_series(self, series: pd.Series) -> pd.Series:
+        """Normalize Tibber prices while preserving their native resolution.
+
+        The Tibber API delivers either hourly or quarter-hourly prices. EOS resamples
+        the stored records onto the optimization grid on demand (``key_to_array``), so
+        the provider must keep the native step size (e.g. 15 minutes) instead of
+        pre-aggregating to hourly values. Duplicate timestamps are collapsed (mean) and
+        the series is sorted, but the resolution is left untouched.
+        """
         if series.empty:
             return series
         series = series.sort_index()
         series.index = pd.to_datetime([to_datetime(index).isoformat() for index in series.index])
-        return series.resample("1h").mean().dropna()
+        series = series.groupby(level=0).mean().sort_index()
+        return series.dropna()
+
+    def _resolution_seconds(self, series: pd.Series) -> int:
+        """Infer the native slot size in seconds from the series timestamps.
+
+        Uses the median of the timestamp differences so that a single outlier gap does
+        not distort the result. Falls back to hourly (3600 s) when fewer than two
+        timestamps are available.
+        """
+        if len(series) < 2:
+            return 3600
+        deltas = pd.DatetimeIndex(series.index).to_series().diff().dropna()
+        if deltas.empty:
+            return 3600
+        resolution = int(round(deltas.dt.total_seconds().median()))
+        return resolution if resolution > 0 else 3600
 
     def _cap_outliers(self, data: np.ndarray, sigma: int = 2) -> np.ndarray:
         mean = data.mean()
@@ -272,33 +295,48 @@ class ElecPriceTibber(ElecPriceProvider):
         clean_history = self._cap_outliers(history)
         return np.full(hours, np.median(clean_history))
 
-    def _predict_missing_prices(self, history: np.ndarray, hours: int) -> np.ndarray:
-        """Forecast missing future prices from the available hourly history."""
+    def _predict_missing_prices(
+        self, history: np.ndarray, slots: int, slots_per_hour: int
+    ) -> np.ndarray:
+        """Forecast missing future prices from the available history.
+
+        Works on the native resolution of the series: ``slots_per_hour`` scales the
+        hour-based seasonal windows into slot counts, so the seasonal periods and
+        history thresholds stay correct at both hourly (``slots_per_hour == 1``) and
+        quarter-hourly (``slots_per_hour == 4``) resolution.
+        """
         numeric_history = np.asarray(history, dtype=float)
         numeric_history = numeric_history[np.isfinite(numeric_history)]
-        history_hours = len(numeric_history)
+        history_slots = len(numeric_history)
 
-        if history_hours > TIBBER_WEEKLY_SEASONAL_HOURS:
+        weekly_seasonal_slots = TIBBER_WEEKLY_SEASONAL_HOURS * slots_per_hour
+        daily_seasonal_slots = TIBBER_DAILY_SEASONAL_HOURS * slots_per_hour
+
+        if history_slots > weekly_seasonal_slots:
             logger.info(
                 "Using weekly seasonal ETS forecast for Tibber electricity prices "
-                "with {} historical hourly values.",
-                history_hours,
+                "with {} historical values.",
+                history_slots,
             )
-            return self._predict_ets(numeric_history, seasonal_periods=168, hours=hours)
-        if history_hours > TIBBER_DAILY_SEASONAL_HOURS:
+            return self._predict_ets(
+                numeric_history, seasonal_periods=168 * slots_per_hour, hours=slots
+            )
+        if history_slots > daily_seasonal_slots:
             logger.info(
                 "Using daily seasonal ETS forecast for Tibber electricity prices "
-                "with {} historical hourly values.",
-                history_hours,
+                "with {} historical values.",
+                history_slots,
             )
-            return self._predict_ets(numeric_history, seasonal_periods=24, hours=hours)
-        if history_hours > 0:
+            return self._predict_ets(
+                numeric_history, seasonal_periods=24 * slots_per_hour, hours=slots
+            )
+        if history_slots > 0:
             logger.warning(
                 "Using median fallback for Tibber electricity prices because only {} "
-                "historical hourly values are available.",
-                history_hours,
+                "historical values are available.",
+                history_slots,
             )
-            return self._predict_median(numeric_history, hours=hours)
+            return self._predict_median(numeric_history, hours=slots)
 
         logger.error("No data available for prediction")
         raise ValueError("No data available")
@@ -310,9 +348,12 @@ class ElecPriceTibber(ElecPriceProvider):
             raise ValueError(f"Start DateTime not set: {self.ems_start_datetime}")
 
         api_history_count, api_today_count, api_tomorrow_count = self._api_price_counts(tibber_data)
-        series_data = self._hourly_series(self._parse_data(tibber_data))
+        series_data = self._normalize_series(self._parse_data(tibber_data))
         if series_data.empty:
-            raise ValueError("Tibber response contains no usable hourly price points")
+            raise ValueError("Tibber response contains no usable price points")
+
+        resolution_seconds = self._resolution_seconds(series_data)
+        slots_per_hour = round(3600 / resolution_seconds)
 
         highest_orig_datetime = to_datetime(series_data.index.max())
         self.key_from_series("elecprice_marketprice_wh", series_data)
@@ -320,6 +361,7 @@ class ElecPriceTibber(ElecPriceProvider):
         history = self.key_to_array(
             key="elecprice_marketprice_wh",
             end_datetime=highest_orig_datetime,
+            interval=to_duration(f"{resolution_seconds} seconds"),
             fill_method="linear",
         )
 
@@ -328,36 +370,41 @@ class ElecPriceTibber(ElecPriceProvider):
             logger.error(error_msg)
             raise ValueError(error_msg)
 
-        needed_hours = int(
-            self.config.prediction.hours
-            - ((highest_orig_datetime - self.ems_start_datetime).total_seconds() // 3600)
-        )
+        covered_slots = (
+            highest_orig_datetime - self.ems_start_datetime
+        ).total_seconds() // resolution_seconds
+        needed_slots = int(self.config.prediction.hours * slots_per_hour - covered_slots)
 
-        if needed_hours <= 0:
+        if needed_slots <= 0:
             logger.warning(
                 "No prediction needed. "
-                f"needed_hours={needed_hours}, "
+                f"needed_slots={needed_slots}, "
                 f"hours={self.config.prediction.hours}, "
+                f"slots_per_hour={slots_per_hour}, "
                 f"highest_orig_datetime={highest_orig_datetime}, "
                 f"start_datetime={self.ems_start_datetime}"
             )
             return
 
         logger.info(
-            "Tibber electricity price input: api_history_hours={}, api_today_hours={}, "
-            "api_tomorrow_hours={}, combined_history_hours={}, needed_forecast_hours={}.",
+            "Tibber electricity price input: api_history={}, api_today={}, "
+            "api_tomorrow={}, resolution_seconds={}, combined_history_slots={}, "
+            "needed_forecast_slots={}.",
             api_history_count,
             api_today_count,
             api_tomorrow_count,
+            resolution_seconds,
             len(history),
-            needed_hours,
+            needed_slots,
         )
-        prediction = self._predict_missing_prices(history, hours=needed_hours)
+        prediction = self._predict_missing_prices(
+            history, slots=needed_slots, slots_per_hour=slots_per_hour
+        )
 
         prediction_series = pd.Series(
             data=prediction,
             index=[
-                highest_orig_datetime + to_duration(f"{i + 1} hours")
+                highest_orig_datetime + to_duration(f"{(i + 1) * resolution_seconds} seconds")
                 for i in range(len(prediction))
             ],
         )

--- a/tests/test_elecpricetibber.py
+++ b/tests/test_elecpricetibber.py
@@ -175,14 +175,41 @@ def test_parse_data_combines_sorts_and_converts_total(provider, tibber_response)
     assert series.iloc[2] == pytest.approx(0.00030468)
 
 
-def test_tibber_hourly_series_averages_quarter_hour_prices(provider):
-    """Quarter-hour Tibber prices are averaged to hourly EOS prices."""
+def test_tibber_normalize_series_preserves_quarter_hour_resolution(provider):
+    """Quarter-hour Tibber prices keep their native 15-min resolution (no averaging).
+
+    EOS resamples onto the optimization grid on demand, so the provider must store the
+    native step size instead of pre-aggregating quarter-hour prices to hourly values.
+    """
     index = pd.date_range("2026-07-09T00:00:00+00:00", periods=8, freq="15min")
-    series = pd.Series([0.10, 0.30, 0.50, 0.70, 1.0, 1.4, 1.8, 2.2], index=index)
+    values = [0.10, 0.30, 0.50, 0.70, 1.0, 1.4, 1.8, 2.2]
+    series = pd.Series(values, index=index)
 
-    hourly = provider._hourly_series(series)
+    normalized = provider._normalize_series(series)
 
-    assert hourly.tolist() == pytest.approx([0.40, 1.60])
+    # Every 15-min point survives, values untouched, still on a 15-min grid.
+    assert normalized.tolist() == pytest.approx(values)
+    deltas = normalized.index.to_series().diff().dropna().dt.total_seconds().unique().tolist()
+    assert deltas == [900.0]
+    assert provider._resolution_seconds(normalized) == 900
+
+
+def test_tibber_normalize_series_deduplicates_timestamps(provider):
+    """Duplicate timestamps are collapsed (mean) without changing the resolution."""
+    index = pd.DatetimeIndex(
+        [
+            "2026-07-09T00:00:00+00:00",
+            "2026-07-09T00:00:00+00:00",
+            "2026-07-09T01:00:00+00:00",
+        ]
+    )
+    series = pd.Series([0.10, 0.30, 0.50], index=index)
+
+    normalized = provider._normalize_series(series)
+
+    assert len(normalized) == 2
+    assert normalized.iloc[0] == pytest.approx(0.20)
+    assert normalized.iloc[1] == pytest.approx(0.50)
 
 
 def test_empty_tomorrow_stores_only_today_and_warns(provider):
@@ -223,6 +250,7 @@ def test_request_forecast_uses_tibber_graphql_api(
     assert "query" in kwargs["json"]
     assert "TibberPriceInfo" in kwargs["json"]["query"]
     assert "priceInfoRange" in kwargs["json"]["query"]
+    assert "QUARTER_HOURLY" in kwargs["json"]["query"]
     assert "total" in kwargs["json"]["query"]
     assert kwargs["timeout"] == 30
 
@@ -299,3 +327,62 @@ def test_tibber_update_uses_eos_storage_history_when_api_history_is_missing(
 
     assert forecast_call["seasonal_periods"] == 168
     assert forecast_call["history_hours"] > 840
+
+
+def test_tibber_update_preserves_quarter_hour_resolution_and_slots(
+    tibber_provider, monkeypatch
+):
+    """15-minute Tibber prices are stored natively and extrapolated on the slot grid.
+
+    Proves the resolution-agnostic path: (a) the native 15-min resolution survives
+    storage, (b) the ETS extrapolation scales the seasonal window into slots
+    (daily-only history -> 24*4 = 96 seasonal periods), and (c) the forecast index is
+    spaced at 15-minute steps.
+    """
+    data = TibberGraphQLResponse.model_validate(
+        _tibber_payload(
+            [
+                _price("2026-07-09T00:00:00+00:00", 0.30),
+                _price("2026-07-09T00:15:00+00:00", 0.42),
+                _price("2026-07-09T00:30:00+00:00", 0.36),
+            ],
+            include_history_range=False,
+        )
+    )
+    monkeypatch.setattr(tibber_provider, "_request_forecast", lambda **_: data)
+    forecast_call = {}
+
+    def fake_predict_ets(history, seasonal_periods, hours):
+        forecast_call["seasonal_periods"] = seasonal_periods
+        forecast_call["history_slots"] = len(history)
+        forecast_call["forecast_slots"] = hours
+        return np.full(hours, 0.0009)
+
+    monkeypatch.setattr(tibber_provider, "_predict_ets", fake_predict_ets)
+
+    # A bit more than one week of quarter-hour history: enough for the daily seasonal
+    # window (> 24*7*4 = 672 slots) but below the weekly one (<= 24*35*4 = 3360 slots).
+    stored_history = pd.Series(
+        data=np.linspace(0.0002, 0.0004, 800),
+        index=pd.date_range("2026-07-01T00:00:00+00:00", periods=800, freq="15min"),
+    )
+    tibber_provider.key_from_series("elecprice_marketprice_wh", stored_history)
+
+    tibber_provider._update_data(force_update=True)
+
+    # (b) Daily seasonal window scaled into 15-min slots.
+    assert forecast_call["seasonal_periods"] == 96
+    assert 672 < forecast_call["history_slots"] <= 3360
+    # prediction.hours (6) * slots_per_hour (4) - covered slots (2 -> 00:00..00:30) = 22
+    assert forecast_call["forecast_slots"] == 22
+
+    # (a)+(c) Stored records keep the native 15-min grid across today and the forecast.
+    stored = tibber_provider.key_to_series(
+        "elecprice_marketprice_wh",
+        start_datetime=to_datetime("2026-07-09T00:00:00+00:00"),
+        end_datetime=to_datetime("2026-07-09T06:15:00+00:00"),
+    )
+    steps = stored.index.to_series().diff().dropna().dt.total_seconds().unique().tolist()
+    assert steps == [900.0]
+    # 00:00..06:00 inclusive at 15-min steps = 25 points (3 API + 22 forecast).
+    assert len(stored) == 25

--- a/tests/test_optimization_interval.py
+++ b/tests/test_optimization_interval.py
@@ -1,0 +1,148 @@
+"""Tests for the 15-minute optimization interval.
+
+The genetic optimizer runs on a fixed slot grid whose length is
+``prediction.hours * (3600 / interval)``. At the default interval of 3600 s this
+is the established hourly behaviour (covered by ``test_geneticoptimize.py``);
+here we cover the 900 s (15 min) slot grid.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from akkudoktoreos.config.config import ConfigEOS
+from akkudoktoreos.core.cache import CacheEnergyManagementStore
+from akkudoktoreos.core.coreabc import get_ems
+from akkudoktoreos.optimization.genetic.genetic import GeneticOptimization
+from akkudoktoreos.optimization.genetic.geneticparams import (
+    GeneticOptimizationParameters,
+)
+from akkudoktoreos.utils.datetimeutil import to_datetime
+from akkudoktoreos.utils.visualize import prepare_visualize
+
+ems_eos = get_ems(init=True)  # init once
+
+DIR_TESTDATA = Path(__file__).parent / "testdata"
+
+
+@pytest.mark.parametrize(
+    "interval, exp_slots_per_hour, exp_slot_duration_h",
+    [
+        (3600, 1, 1.0),
+        (900, 4, 0.25),
+    ],
+)
+def test_slot_helpers(
+    config_eos: ConfigEOS,
+    interval: int,
+    exp_slots_per_hour: int,
+    exp_slot_duration_h: float,
+):
+    """slot_duration_h / slots_per_hour / total_slots track the configured interval."""
+    config_eos.merge_settings_from_dict(
+        {
+            "prediction": {"hours": 48},
+            "optimization": {"horizon_hours": 48, "interval": interval},
+        }
+    )
+    ems_eos.set_start_datetime(to_datetime().set(hour=10, minute=0))
+
+    opt = GeneticOptimization(fixed_seed=42)
+
+    assert opt.slots_per_hour == exp_slots_per_hour
+    assert opt.slot_duration_h == exp_slot_duration_h
+    assert opt.total_slots == 48 * exp_slots_per_hour
+    # At minute 0 the start slot is the hour scaled by the slot count.
+    assert opt._start_day_slot() == 10 * exp_slots_per_hour
+
+
+def test_start_day_slot_includes_minute_offset(config_eos: ConfigEOS):
+    """At 15-min resolution the start slot includes the minute offset."""
+    config_eos.merge_settings_from_dict(
+        {
+            "prediction": {"hours": 48},
+            "optimization": {"horizon_hours": 48, "interval": 900},
+        }
+    )
+    ems_eos.set_start_datetime(to_datetime().set(hour=10, minute=30))
+
+    opt = GeneticOptimization(fixed_seed=42)
+
+    # Slot index is derived from the actual EMS start datetime (which may be
+    # floored to the hour by the energy management system): hour*4 + minute//15.
+    sd = opt.ems.start_datetime
+    assert opt._start_day_slot() == sd.hour * 4 + sd.minute // 15
+
+
+def test_optimize_15min_slot_grid(config_eos: ConfigEOS):
+    """An end-to-end optimization at interval=900 runs on a 192-slot day grid.
+
+    This exercises the full path (parameter preparation, GA core, device
+    simulation, solution/plan serialization) at 15-min resolution and asserts the
+    structural properties; the optimization result itself is not pinned because
+    the 15-min grid is a different problem than the hourly one.
+    """
+    config_eos.merge_settings_from_dict(
+        {
+            "prediction": {"hours": 48},
+            "optimization": {
+                "horizon_hours": 48,
+                "interval": 900,
+                "genetic": {
+                    "individuals": 300,
+                    "generations": 10,
+                    "penalties": {
+                        "ev_soc_miss": 10,
+                        "ac_charge_break_even": 0,
+                    },
+                },
+            },
+            "devices": {
+                "max_electric_vehicles": 1,
+                "electric_vehicles": [
+                    {
+                        "charge_rates": [0.0, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0],
+                    }
+                ],
+            },
+        }
+    )
+
+    with (DIR_TESTDATA / "optimize_input_1.json").open("r") as f_in:
+        input_data = GeneticOptimizationParameters(**json.load(f_in))
+
+    ems_eos.set_start_datetime(to_datetime().set(hour=10, minute=0))
+    CacheEnergyManagementStore().clear()
+
+    opt = GeneticOptimization(fixed_seed=42)
+    assert opt.total_slots == 192
+    assert opt.slot_duration_h == 0.25
+
+    visualize_filename = str((DIR_TESTDATA / "new_optimize_15min.json").with_suffix(".pdf"))
+    with patch(
+        "akkudoktoreos.utils.visualize.prepare_visualize",
+        side_effect=lambda parameters, results, *args, **kwargs: prepare_visualize(
+            parameters, results, filename=visualize_filename, **kwargs
+        ),
+    ):
+        genetic_solution = opt.optimierung_ems(
+            parameters=input_data, start_hour=10, ngen=3
+        )
+
+    # The genetic core emitted a full-day grid at 15-min resolution.
+    assert len(genetic_solution.ac_charge) == 192
+    assert len(genetic_solution.dc_charge) == 192
+    assert len(genetic_solution.discharge_allowed) == 192
+
+    # The serializers consume the 15-min grid without error and emit a 900 s
+    # spaced solution index.
+    solution = genetic_solution.optimization_solution()
+    df = solution.solution.to_dataframe()
+    assert len(df.index) >= 2
+    delta_seconds = (df.index[1] - df.index[0]).total_seconds()
+    assert delta_seconds == 900
+
+    plan = genetic_solution.energy_management_plan()
+    assert plan is not None


### PR DESCRIPTION
Builds on the new forecast providers introduced in `codex/fehler-im-ladealgorithmus-untersuchen` to bring end-to-end 15-minute operation to EOS.

**Retargeted** from `main` to `codex/fehler-im-ladealgorithmus-untersuchen`, because the 15-minute grid only delivers real value together with the sub-hourly providers added on that branch (pvnode, Forecast.Solar, Solcast, Tibber).

### What this adds
- **15-minute optimization interval for the genetic optimizer.** `optimization.interval` now accepts `900` (15 min) in addition to the default `3600` (1 h). The genetic optimizer, device power caps (battery/inverter/home appliance) and the solution/plan serializers are slot-aware (`total_slots = prediction.hours * 3600/interval`). The default `3600 s` keeps byte-identical hourly behaviour.
- **Central resampling, not per-provider rebuilds.** Provider records stay at their native resolution; `key_to_array(interval=…)` maps them onto the slot grid (PV linear-interpolated, prices/load ffill, power series scaled to Wh/slot). The new sub-hourly PV providers (pvnode 15 min, Solcast 30 min, Forecast.Solar) feed their native resolution straight into the quarter-hour grid.
- **Native 15-minute Tibber prices.** `ElecPriceTibber` now requests `priceInfoRange(resolution: QUARTER_HOURLY)` and stores prices at their native resolution instead of averaging them to 1 h, so both the hourly and the 15-minute optimizer get the correct grid. The seasonal ETS extrapolation is resolution-agnostic and stays identical at the default hourly resolution.

### Tests
- `tests/test_optimization_interval.py` → 4 passed (end-to-end 192-slot day, 900 s output cadence)
- `tests/test_elecpricetibber.py` → 15 passed (native-15min preservation + hourly backward-compat)

### Note on pre-existing failures
`tests/test_geneticoptimize.py` has 4 failures that are **pre-existing on this codex branch** (commit `cd5cdf8` "fix: limit EV charging to unmet min SoC" changed `eautocharge_hours_float` without updating the expected `optimize_result_*.json` fixtures). They are inherited from the base branch, not introduced by this PR — verified by a three-way comparison of both merge parents.
