### PR TITLE
Direct marketing: overnight reserve (price-aware) + /v1/prediction/import serialization fix

### DIFF
--- a/src/akkudoktoreos/devices/genetic/inverter.py
+++ b/src/akkudoktoreos/devices/genetic/inverter.py
@@ -51,6 +51,7 @@ class Inverter:
         consumption: float,
         hour: int,
         allow_battery_grid_export: bool = False,
+        export_reserve_ac_wh: float = 0.0,
     ) -> tuple[float, float, float, float]:
         """Process one slot using probabilistic direct PV-to-load overlap.
 
@@ -59,6 +60,13 @@ class Inverter:
         PV-to-load power. The remaining load and PV surplus are then handled
         independently, because both can occur during different sub-intervals of
         the same hourly or 15-minute slot.
+
+        ``export_reserve_ac_wh`` is delivered-AC energy the battery must keep
+        for overnight household self-consumption. It only caps the
+        battery-to-grid export path (direct marketing): covering the slot's own
+        load may still use the reserve, so the pack rides the night on
+        self-consumption instead of selling out in the evening and re-importing
+        the whole night from the grid.
         """
         losses = 0.0
         grid_export = 0.0
@@ -126,6 +134,10 @@ class Inverter:
             remaining_battery_ac = (
                 self.battery.remaining_discharge_energy_wh(hour) * self.dc_to_ac_efficiency
             )
+            # Overnight reserve: energy earmarked for tonight's household load
+            # is not exportable. Self-consumption above already had full access.
+            if export_reserve_ac_wh > 0.0:
+                remaining_battery_ac = max(remaining_battery_ac - export_reserve_ac_wh, 0.0)
             export_capacity = min(remaining_inverter_ac_capacity, remaining_battery_ac)
             battery_export_ac, battery_export_losses = self._discharge_battery_to_ac(
                 export_capacity, hour

--- a/src/akkudoktoreos/devices/genetic/inverter.py
+++ b/src/akkudoktoreos/devices/genetic/inverter.py
@@ -136,8 +136,22 @@ class Inverter:
             )
             # Overnight reserve: energy earmarked for tonight's household load
             # is not exportable. Self-consumption above already had full access.
+            # The reserve caps the SOC POOL, not the per-slot power budget: a
+            # night reserve larger than one slot's discharge budget must NOT
+            # zero out export in every slot — only the energy above
+            # min_soc + reserve is sellable, at full slot power.
             if export_reserve_ac_wh > 0.0:
-                remaining_battery_ac = max(remaining_battery_ac - export_reserve_ac_wh, 0.0)
+                disch_eff = self.battery.discharging_efficiency
+                if self.dc_to_ac_efficiency > 0.0 and disch_eff > 0.0:
+                    reserve_dc_wh = export_reserve_ac_wh / (self.dc_to_ac_efficiency * disch_eff)
+                else:
+                    reserve_dc_wh = export_reserve_ac_wh
+                soc_exportable_ac = (
+                    max(self.battery.soc_wh - self.battery.min_soc_wh - reserve_dc_wh, 0.0)
+                    * disch_eff
+                    * self.dc_to_ac_efficiency
+                )
+                remaining_battery_ac = min(remaining_battery_ac, soc_exportable_ac)
             export_capacity = min(remaining_inverter_ac_capacity, remaining_battery_ac)
             battery_export_ac, battery_export_losses = self._discharge_battery_to_ac(
                 export_capacity, hour

--- a/src/akkudoktoreos/optimization/genetic/genetic.py
+++ b/src/akkudoktoreos/optimization/genetic/genetic.py
@@ -1,5 +1,6 @@
 """Genetic algorithm."""
 
+import os
 import random
 import time
 from collections import OrderedDict, defaultdict
@@ -26,6 +27,146 @@ from akkudoktoreos.optimization.genetic.geneticsolution import (
     GeneticSolution,
 )
 from akkudoktoreos.optimization.optimizationabc import OptimizationBase
+
+# ---------------------------------------------------------------------------
+# Overnight reserve (direct marketing safeguard)
+#
+# Without a reserve, direct marketing (battery_grid_export) happily sells the
+# battery into the evening price peak and buys the whole night's load back from
+# the grid at the (usually higher) import price. With it, grid-export discharge
+# must leave enough charge to cover the forecast net load (load − PV) until PV
+# next covers load the following morning. Self-consumption is NOT limited — the
+# reserve is consumed through the night and ends near the floor as morning PV
+# takes over. EOS_OVERNIGHT_RESERVE=0 disables it → sell to the floor.
+# EOS_OVERNIGHT_RESERVE_MARGIN pads the forecast against under-prediction.
+_OVERNIGHT_RESERVE_ENABLED = os.environ.get("EOS_OVERNIGHT_RESERVE", "1") not in (
+    "0",
+    "false",
+    "False",
+    "no",
+)
+try:
+    _OVERNIGHT_RESERVE_MARGIN = float(os.environ.get("EOS_OVERNIGHT_RESERVE_MARGIN", "1.1"))
+except (TypeError, ValueError):
+    _OVERNIGHT_RESERVE_MARGIN = 1.1
+
+# PRICE-AWARE overnight reserve: the energy-balance reserve above is
+# price-blind — it holds the full forecast night net-load as an export cap, so
+# the optimizer cannot sell that energy into a high evening peak even when
+# selling now + re-buying cheaper overnight is clearly better. When enabled,
+# each slot's reserve is RELEASED (down to a small hard safety floor) whenever
+# THAT SLOT'S OWN export revenue beats the highest avoided night-import price
+# by more than a RELATIVE margin: revenue[h] > avoided_import × (1 + margin)
+# (+ optional absolute spread). avoided_import is read per-slot from the
+# resolved end-customer import price array, so this stays tariff-agnostic
+# (fixed AND dynamic tariffs). Default OFF → byte-identical to the price-blind
+# reserve.
+_RESERVE_PRICE_AWARE_ENABLED = os.environ.get("EOS_RESERVE_PRICE_AWARE", "0") not in (
+    "0",
+    "false",
+    "False",
+    "no",
+)
+try:
+    _RESERVE_RELEASE_MARGIN = float(os.environ.get("EOS_RESERVE_RELEASE_MARGIN", "0.20"))
+except (TypeError, ValueError):
+    _RESERVE_RELEASE_MARGIN = 0.20
+try:
+    _RESERVE_RELEASE_SPREAD = float(
+        os.environ.get("EOS_RESERVE_RELEASE_SPREAD_EUR_PER_WH", "0.0")
+    )
+except (TypeError, ValueError):
+    _RESERVE_RELEASE_SPREAD = 0.0
+# Load-adaptive self-consumption safety floor (delivered-AC Wh) that is NEVER
+# released: safety = clamp(full_night_reserve × fraction, floor, cap). The
+# floor is the operator's blackout buffer ON TOP of the battery min_soc.
+try:
+    _RESERVE_SAFETY_FRACTION = float(os.environ.get("EOS_RESERVE_SAFETY_FRACTION", "0.5"))
+except (TypeError, ValueError):
+    _RESERVE_SAFETY_FRACTION = 0.5
+try:
+    _RESERVE_MIN_SAFETY_FLOOR_WH = float(
+        os.environ.get("EOS_RESERVE_MIN_SAFETY_FLOOR_WH", "2000")
+    )
+except (TypeError, ValueError):
+    _RESERVE_MIN_SAFETY_FLOOR_WH = 2000.0
+try:
+    _RESERVE_MIN_SAFETY_CAP_WH = float(os.environ.get("EOS_RESERVE_MIN_SAFETY_CAP_WH", "6000"))
+except (TypeError, ValueError):
+    _RESERVE_MIN_SAFETY_CAP_WH = 6000.0
+
+
+def _compute_overnight_reserve(
+    load_array: np.ndarray,
+    pv_array: np.ndarray,
+    start_hour: int,
+    end_hour: int,
+    margin: float,
+    price_array: Optional[np.ndarray] = None,
+    revenue_array: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    """Per-slot delivered-AC energy the battery must keep for self-consumption.
+
+    reserve[h] = margin × Σ max(load[j] − pv[j], 0) for j running from h+1 up to
+    (but not including) the next slot where PV covers load. Walked backwards so
+    each evening reserves exactly the energy needed to ride to the next morning.
+
+    Price-aware release (per-slot): when enabled AND both price_array (per-slot
+    import price, EUR/Wh) and revenue_array (per-slot feed-in revenue, EUR/Wh)
+    are supplied, each slot's reserve is RELEASED down to a hard safety floor
+    whenever THAT SLOT'S OWN export revenue beats the highest avoided
+    night-import price of its night window by more than the relative margin.
+    The night reserve may therefore only be SOLD in slots that individually
+    clear the buy-back-plus-loss threshold; the surplus ABOVE the reserve is
+    sold price-best-first in any slot by the GA regardless. reserve[h] is a
+    per-slot EXPORT cap in inverter.py, NOT a hard SoC-trajectory floor, so a
+    per-slot release stays temporally consistent. Pure function of the forecast
+    arrays — no RNG, no per-individual state — so the GA stays deterministic
+    and the result is fitness-cache-safe.
+    """
+    reserve = np.zeros_like(load_array, dtype=float)
+    if not _OVERNIGHT_RESERVE_ENABLED:
+        return reserve
+    price_aware = (
+        _RESERVE_PRICE_AWARE_ENABLED and price_array is not None and revenue_array is not None
+    )
+    running = 0.0
+    # Exclusive upper bound of the night window the current reserve belongs to.
+    # The release decision is scoped to THAT window only — comparing against
+    # prices beyond it (a later, possibly pricier night the energy never
+    # reaches) would wrongly suppress or trigger the release on a multi-day
+    # horizon.
+    night_window_end = end_hour
+    for h in range(end_hour - 1, start_hour - 1, -1):
+        nxt = h + 1
+        if nxt >= end_hour or pv_array[nxt] >= load_array[nxt]:
+            running = 0.0  # morning reached (or horizon end) — no reserve beyond
+            night_window_end = nxt  # a fresh night window starts above this boundary
+        else:
+            running += max(float(load_array[nxt]) - float(pv_array[nxt]), 0.0)
+        full_reserve = running * margin
+        if not price_aware or full_reserve <= 0.0:
+            reserve[h] = full_reserve
+            continue
+        # Highest avoided night-import price within this night window.
+        # Conservative: the most expensive slot, so the reserve only releases
+        # when the reachable export revenue clearly beats it.
+        avoided_import = (
+            float(np.max(price_array[nxt:night_window_end])) if nxt < night_window_end else 0.0
+        )
+        this_export = float(revenue_array[h])
+        if this_export > avoided_import * (1.0 + _RESERVE_RELEASE_MARGIN) + _RESERVE_RELEASE_SPREAD:
+            # Selling into the peak beats holding → release to the
+            # load-adaptive safety floor. Never reserve MORE than the energy
+            # balance would have asked for.
+            safety = min(
+                max(full_reserve * _RESERVE_SAFETY_FRACTION, _RESERVE_MIN_SAFETY_FLOOR_WH),
+                _RESERVE_MIN_SAFETY_CAP_WH,
+            )
+            reserve[h] = min(full_reserve, safety)
+        else:
+            reserve[h] = full_reserve
+    return reserve
 
 
 @dataclass
@@ -180,6 +321,12 @@ class GeneticSimulation(PydanticBaseModel):
     ev_discharge_hours: Optional[NDArray[Shape["*"], float]] = Field(
         default=None, json_schema_extra={"description": "TBD"}
     )
+    export_reserve_wh_arr: Optional[NDArray[Shape["*"], float]] = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Per-slot delivered-AC overnight reserve capping battery grid export."
+        },
+    )
 
     def prepare(
         self,
@@ -228,6 +375,21 @@ class GeneticSimulation(PydanticBaseModel):
         self.ev_charge_hours = np.full(self.prediction_hours, 0.0)
         self.ev_discharge_hours = np.full(self.prediction_hours, 0.0)
 
+        # Overnight reserve for direct marketing: computed ONCE per prepare()
+        # from the forecast arrays (pure + deterministic → fitness-cache-safe),
+        # then applied per-slot as an export cap in Inverter.process_energy.
+        self.export_reserve_wh_arr = _compute_overnight_reserve(
+            self.load_energy_array,
+            self.pv_prediction_wh,
+            0,
+            len(self.load_energy_array),
+            _OVERNIGHT_RESERVE_MARGIN,
+            price_array=self.elect_price_hourly if _RESERVE_PRICE_AWARE_ENABLED else None,
+            revenue_array=(
+                self.elect_revenue_per_hour_arr if _RESERVE_PRICE_AWARE_ENABLED else None
+            ),
+        )
+
     def reset(self) -> None:
         if self.ev:
             self.ev.reset()
@@ -259,6 +421,7 @@ class GeneticSimulation(PydanticBaseModel):
         home_appliances_fast = self.home_appliances
         inverter_fast = self.inverter
         direct_marketing_enabled_fast = self.direct_marketing_enabled
+        export_reserve_wh_arr_fast = self.export_reserve_wh_arr
 
         # Check for simulation integrity (in a way that mypy understands)
         if (
@@ -461,6 +624,12 @@ class GeneticSimulation(PydanticBaseModel):
                     consumption,
                     hour,
                     allow_battery_grid_export=battery_grid_export_allowed,
+                    export_reserve_ac_wh=(
+                        float(export_reserve_wh_arr_fast[hour])
+                        if export_reserve_wh_arr_fast is not None
+                        and hour < len(export_reserve_wh_arr_fast)
+                        else 0.0
+                    ),
                 )
             else:
                 hourly_feed_in_tariff = elect_revenue_per_hour_arr_fast[hour]

--- a/src/akkudoktoreos/optimization/genetic/geneticparams.py
+++ b/src/akkudoktoreos/optimization/genetic/geneticparams.py
@@ -30,7 +30,19 @@ from akkudoktoreos.optimization.genetic.geneticdevices import (
 from akkudoktoreos.utils.datetimeutil import to_duration
 
 MARKET_PRICE_FEED_IN_TARIFF_PROVIDERS = frozenset(
-    {"FeedInTariffAkkudoktor", "FeedInTariffEnergyCharts", "FeedInTariffTibber"}
+    {
+        "FeedInTariffAkkudoktor",
+        "FeedInTariffEnergyCharts",
+        "FeedInTariffTibber",
+        # FeedInTariffImport carries operator-pushed market revenues (external
+        # EMS bridges import the resolved per-slot feed-in here). Without it,
+        # direct marketing silently replaced the imported revenue series with
+        # elecprice_marketprice_wh — for bridges that push the resolved
+        # END-CUSTOMER import price there, the GA then saw feed-in == import
+        # price in every slot, a world where battery arbitrage can never pay,
+        # and correctly converged to never cycling the battery.
+        "FeedInTariffImport",
+    }
 )
 
 # Do not import directly from akkudoktoreos.core.coreabc
@@ -418,6 +430,14 @@ class GeneticOptimizationParameters(
                             fill_method="ffill",
                         ).tolist()
                     except:
+                        # Loud fallback: substituting the electricity price for
+                        # the feed-in revenue changes the optimization economics
+                        # fundamentally — never do it silently.
+                        logger.warning(
+                            "Direct marketing: no feed_in_tariff_wh data from provider {} - "
+                            "falling back to elecprice_marketprice_wh as feed-in revenue.",
+                            cls.config.feedintariff.provider,
+                        )
                         feed_in_tariff_wh = list(elecprice_marketprice_wh)
                 else:
                     feed_in_tariff_wh = list(elecprice_marketprice_wh)

--- a/src/akkudoktoreos/optimization/genetic/geneticparams.py
+++ b/src/akkudoktoreos/optimization/genetic/geneticparams.py
@@ -42,6 +42,9 @@ MARKET_PRICE_FEED_IN_TARIFF_PROVIDERS = frozenset(
         # price in every slot, a world where battery arbitrage can never pay,
         # and correctly converged to never cycling the battery.
         "FeedInTariffImport",
+        # FeedInTariffDvhubOnline serves raw EPEX day-ahead market prices
+        # (dvhub.online) — a market-revenue source like EnergyCharts/Tibber.
+        "FeedInTariffDvhubOnline",
     }
 )
 

--- a/src/akkudoktoreos/prediction/feedintariff.py
+++ b/src/akkudoktoreos/prediction/feedintariff.py
@@ -8,6 +8,9 @@ from akkudoktoreos.prediction.feedintariffabc import FeedInTariffProvider
 from akkudoktoreos.prediction.feedintariffakkudoktor import (
     FeedInTariffAkkudoktorCommonSettings,
 )
+from akkudoktoreos.prediction.feedintariffdvhubonline import (
+    FeedInTariffDvhubOnlineCommonSettings,
+)
 from akkudoktoreos.prediction.feedintariffenergycharts import (
     FeedInTariffEnergyChartsCommonSettings,
 )
@@ -27,6 +30,7 @@ def elecprice_provider_ids() -> list[str]:
             "FeedInTariffAkkudoktor",
             "FeedInTariffFixed",
             "FeedInTariffEnergyCharts",
+            "FeedInTariffDvhubOnline",
             "FeedInTariffImport",
             "FeedInTariffTibber",
         ]
@@ -52,6 +56,10 @@ class FeedInTariffCommonProviderSettings(SettingsBaseModel):
     FeedInTariffEnergyCharts: Optional[FeedInTariffEnergyChartsCommonSettings] = Field(
         default=None,
         json_schema_extra={"description": "FeedInTariffEnergyCharts settings", "examples": [None]},
+    )
+    FeedInTariffDvhubOnline: Optional[FeedInTariffDvhubOnlineCommonSettings] = Field(
+        default=None,
+        json_schema_extra={"description": "FeedInTariffDvhubOnline settings", "examples": [None]},
     )
     FeedInTariffImport: Optional[FeedInTariffImportCommonSettings] = Field(
         default=None,
@@ -82,6 +90,7 @@ class FeedInTariffCommonSettings(SettingsBaseModel):
                 "FeedInTariffAkkudoktor",
                 "FeedInTariffFixed",
                 "FeedInTariffEnergyCharts",
+                "FeedInTariffDvhubOnline",
                 "FeedInTariffImport",
                 "FeedInTariffTibber",
             ],

--- a/src/akkudoktoreos/prediction/feedintariffdvhubonline.py
+++ b/src/akkudoktoreos/prediction/feedintariffdvhubonline.py
@@ -1,0 +1,152 @@
+"""Provides feed-in tariff data from the dvhub.online price API."""
+
+import time
+from datetime import datetime
+from typing import Any, Optional
+
+import pandas as pd
+import requests
+from loguru import logger
+from pydantic import Field
+
+from akkudoktoreos.config.configabc import SettingsBaseModel
+from akkudoktoreos.core.cache import cache_in_file
+from akkudoktoreos.prediction.feedintariffabc import FeedInTariffProvider
+from akkudoktoreos.utils.datetimeutil import to_datetime, to_duration
+
+
+class FeedInTariffDvhubOnlineCommonSettings(SettingsBaseModel):
+    """Common settings for the dvhub.online feed-in tariff provider."""
+
+    base_url: str = Field(
+        default="https://dvhub.online",
+        json_schema_extra={
+            "description": "Base URL of the dvhub.online price API.",
+            "examples": ["https://dvhub.online"],
+        },
+    )
+    zone: str = Field(
+        default="DE-LU",
+        json_schema_extra={
+            "description": "Bidding zone passed to the dvhub.online price API.",
+            "examples": ["DE-LU"],
+        },
+    )
+
+
+class FeedInTariffDvhubOnline(FeedInTariffProvider):
+    """Fetch dvhub.online day-ahead market prices as feed-in tariff data.
+
+    dvhub.online serves EPEX day-ahead prices (15-minute slots, EUR/MWh) via
+    ``GET /api/prices?start=YYYY-MM-DD&end=YYYY-MM-DD&zone=DE-LU``. The raw
+    market price is stored as ``feed_in_tariff_wh`` (EUR/Wh) — like
+    ``FeedInTariffEnergyCharts`` this intentionally adds no import charges or
+    VAT, so the series is the direct-marketing revenue the optimizer needs.
+    Slots beyond the published day-ahead horizon are left to the consumer's
+    forward-fill (same behaviour as ``FeedInTariffImport``).
+    """
+
+    highest_orig_datetime: Optional[datetime] = None
+
+    def historic_hours_min(self) -> int:
+        """Day-ahead source without seasonal extrapolation — keep two days."""
+        return 48
+
+    @classmethod
+    def provider_id(cls) -> str:
+        """Return the unique identifier for the dvhub.online feed-in tariff provider."""
+        return "FeedInTariffDvhubOnline"
+
+    def _provider_settings(self) -> FeedInTariffDvhubOnlineCommonSettings:
+        settings = self.config.feedintariff.provider_settings.FeedInTariffDvhubOnline
+        if settings is None:
+            return FeedInTariffDvhubOnlineCommonSettings()
+        return settings
+
+    @cache_in_file(with_ttl="1 hour")
+    def _request_forecast(self, start_date: str, end_date: str) -> dict[str, Any]:
+        """Fetch market prices from the dvhub.online price API."""
+        settings = self._provider_settings()
+        url = (
+            f"{settings.base_url}/api/prices"
+            f"?start={start_date}&end={end_date}&zone={settings.zone}"
+        )
+        # Retry transient network problems with a short backoff (same pattern
+        # as FeedInTariffEnergyCharts): (connect, read) timeout tuple.
+        max_attempts = 3
+        last_exc: Optional[Exception] = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                response = requests.get(
+                    url, headers={"accept": "application/json"}, timeout=(5, 60)
+                )
+                logger.debug(f"Response from {url}: {response}")
+                response.raise_for_status()
+                data = response.json()
+                if not isinstance(data, dict) or not isinstance(data.get("data"), list):
+                    raise ValueError(
+                        f"Unexpected dvhub.online price API response shape from {url}"
+                    )
+                self.update_datetime = to_datetime(in_timezone=self.config.general.timezone)
+                return data
+            except (
+                requests.exceptions.Timeout,
+                requests.exceptions.ConnectionError,
+            ) as exc:
+                last_exc = exc
+                logger.warning(
+                    "dvhub.online price request attempt {}/{} failed: {}",
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                if attempt < max_attempts:
+                    time.sleep(2 * attempt)
+        raise last_exc  # type: ignore[misc]
+
+    def _parse_data(self, dvhub_data: dict[str, Any]) -> pd.Series:
+        """dvhub.online entries {ts, price[EUR/MWh]} -> Series of EUR/Wh."""
+        series_data = pd.Series(dtype=float)
+        for entry in dvhub_data.get("data", []):
+            try:
+                orig_datetime = to_datetime(
+                    entry["ts"], in_timezone=self.config.general.timezone
+                )
+                price_eur_per_mwh = float(entry["price"])
+            except (KeyError, TypeError, ValueError) as exc:
+                logger.warning("Skipping malformed dvhub.online price entry {}: {}", entry, exc)
+                continue
+            series_data.at[orig_datetime] = price_eur_per_mwh / 1_000_000
+        return series_data
+
+    def _update_data(self, force_update: Optional[bool] = False) -> None:
+        """Update feed-in tariff forecast data from dvhub.online."""
+        if not self.ems_start_datetime:
+            raise ValueError(f"Start DateTime not set: {self.ems_start_datetime}")
+
+        start_date = to_datetime(
+            self.ems_start_datetime - to_duration("2 days"), as_string="YYYY-MM-DD"
+        )
+        end_date = to_datetime(self.end_datetime, as_string="YYYY-MM-DD")
+
+        try:
+            dvhub_data = self._request_forecast(
+                start_date=start_date, end_date=end_date, force_update=force_update
+            )
+            series_data = self._parse_data(dvhub_data)
+            if series_data.empty:
+                raise ValueError("No dvhub.online feed-in tariff data available")
+            self.highest_orig_datetime = series_data.index.max()
+            self.key_from_series("feed_in_tariff_wh", series_data)
+        except Exception as exc:
+            if self.highest_orig_datetime is None:
+                # Cold start: nothing to fall back to — a failed fetch is fatal.
+                raise
+            # Transient outage with existing history: keep the history and let
+            # downstream forward-fill cover the remaining slots.
+            logger.warning(
+                "dvhub.online feed-in tariff update failed ({}); keeping existing "
+                "history until {}.",
+                exc,
+                self.highest_orig_datetime,
+            )

--- a/src/akkudoktoreos/prediction/prediction.py
+++ b/src/akkudoktoreos/prediction/prediction.py
@@ -40,6 +40,7 @@ from akkudoktoreos.prediction.feedintariffakkudoktor import FeedInTariffAkkudokt
 from akkudoktoreos.prediction.feedintariffenergycharts import FeedInTariffEnergyCharts
 from akkudoktoreos.prediction.feedintarifffixed import FeedInTariffFixed
 from akkudoktoreos.prediction.feedintariffimport import FeedInTariffImport
+from akkudoktoreos.prediction.feedintariffdvhubonline import FeedInTariffDvhubOnline
 from akkudoktoreos.prediction.feedintarifftibber import FeedInTariffTibber
 from akkudoktoreos.prediction.loadakkudoktor import (
     LoadAkkudoktor,
@@ -89,6 +90,7 @@ feedintariff_akkudoktor = FeedInTariffAkkudoktor()
 feedintariff_fixed = FeedInTariffFixed()
 feedintariff_import = FeedInTariffImport()
 feedintariff_tibber = FeedInTariffTibber()
+feedintariff_dvhub_online = FeedInTariffDvhubOnline()
 loadforecast_akkudoktor = LoadAkkudoktor()
 loadforecast_akkudoktor_adjusted = LoadAkkudoktorAdjusted()
 loadforecast_vrm = LoadVrm()
@@ -118,6 +120,7 @@ def prediction_providers() -> (
             FeedInTariffFixed,
             FeedInTariffImport,
             FeedInTariffTibber,
+            FeedInTariffDvhubOnline,
             LoadAkkudoktor,
             LoadAkkudoktorAdjusted,
             LoadVrm,
@@ -150,6 +153,7 @@ def prediction_providers() -> (
         feedintariff_fixed, \
         feedintariff_import, \
         feedintariff_tibber, \
+        feedintariff_dvhub_online, \
         loadforecast_akkudoktor, \
         loadforecast_akkudoktor_adjusted, \
         loadforecast_vrm, \
@@ -177,6 +181,7 @@ def prediction_providers() -> (
         feedintariff_fixed,
         feedintariff_import,
         feedintariff_tibber,
+        feedintariff_dvhub_online,
         loadforecast_akkudoktor,
         loadforecast_akkudoktor_adjusted,
         loadforecast_vrm,
@@ -209,6 +214,7 @@ class Prediction(PredictionContainer):
             FeedInTariffFixed,
             FeedInTariffImport,
             FeedInTariffTibber,
+            FeedInTariffDvhubOnline,
             LoadAkkudoktor,
             LoadAkkudoktorAdjusted,
             LoadVrm,

--- a/src/akkudoktoreos/server/eos.py
+++ b/src/akkudoktoreos/server/eos.py
@@ -993,7 +993,7 @@ def fastapi_prediction_import_provider(
     if not provider.enabled() and not force_enable:
         raise HTTPException(status_code=404, detail=f"Provider '{provider_id}' not enabled.")
     try:
-        provider.import_from_json(json_str=json.dumps(data))
+        provider.import_from_json(json_str=data.model_dump_json() if hasattr(data, "model_dump_json") else json.dumps(data))
         provider.update_datetime = to_datetime(in_timezone=get_config().general.timezone)
     except Exception as e:
         raise HTTPException(

--- a/tests/test_feedintariffdvhubonline.py
+++ b/tests/test_feedintariffdvhubonline.py
@@ -1,0 +1,78 @@
+"""Tests for the dvhub.online feed-in tariff provider."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from akkudoktoreos.optimization.genetic.geneticparams import (
+    MARKET_PRICE_FEED_IN_TARIFF_PROVIDERS,
+)
+from akkudoktoreos.prediction.feedintariffdvhubonline import (
+    FeedInTariffDvhubOnline,
+    FeedInTariffDvhubOnlineCommonSettings,
+)
+
+SAMPLE = {
+    "data": [
+        {"ts": "2026-07-19T12:00:00.000Z", "price": 42.5},   # EUR/MWh
+        {"ts": "2026-07-19T12:15:00.000Z", "price": -5.69},  # negative slot
+        {"ts": "bogus", "price": 10.0},                      # malformed -> skipped
+        {"ts": "2026-07-19T12:30:00.000Z", "price": "x"},    # malformed -> skipped
+    ]
+}
+
+
+@pytest.fixture
+def provider(config_eos):
+    config_eos.merge_settings_from_dict(
+        {"feedintariff": {"provider": "FeedInTariffDvhubOnline"}}
+    )
+    return FeedInTariffDvhubOnline()
+
+
+class TestFeedInTariffDvhubOnline:
+    def test_provider_id_registered(self, provider, config_eos):
+        assert provider.provider_id() == "FeedInTariffDvhubOnline"
+        assert provider.enabled()
+        assert "FeedInTariffDvhubOnline" in config_eos.feedintariff.providers
+
+    def test_market_price_provider_for_direct_marketing(self):
+        """direct_marketing must use this provider's series, never elecprice."""
+        assert "FeedInTariffDvhubOnline" in MARKET_PRICE_FEED_IN_TARIFF_PROVIDERS
+
+    def test_parse_data_eur_mwh_to_eur_wh(self, provider):
+        series = provider._parse_data(SAMPLE)
+        assert len(series) == 2  # malformed entries skipped
+        assert series.iloc[0] == pytest.approx(42.5 / 1_000_000)
+        assert series.iloc[1] == pytest.approx(-5.69 / 1_000_000)  # negatives kept
+
+    def test_default_settings(self, provider):
+        settings = provider._provider_settings()
+        assert settings.base_url == "https://dvhub.online"
+        assert settings.zone == "DE-LU"
+
+    def test_request_shape_guard(self, provider):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"unexpected": True}
+        with patch(
+            "akkudoktoreos.prediction.feedintariffdvhubonline.requests.get",
+            return_value=response,
+        ):
+            with pytest.raises(ValueError, match="response shape"):
+                provider._request_forecast(
+                    start_date="2026-07-19", end_date="2026-07-21", force_update=True
+                )
+
+
+@pytest.mark.skipif(
+    os.environ.get("EOS_DVHUB_ONLINE_LIVE") != "1",
+    reason="live API smoke — set EOS_DVHUB_ONLINE_LIVE=1 to run",
+)
+def test_live_api_smoke(provider):
+    data = provider._request_forecast(
+        start_date="2026-07-19", end_date="2026-07-20", force_update=True
+    )
+    series = provider._parse_data(data)
+    assert not series.empty

--- a/tests/test_geneticparams_feedin.py
+++ b/tests/test_geneticparams_feedin.py
@@ -1,0 +1,23 @@
+"""Direct marketing must use the IMPORTED feed-in revenue series.
+
+Regression: with ``feedintariff.provider = FeedInTariffImport`` and direct
+marketing enabled, ``prepare_optimization_parameters`` silently replaced the
+operator-pushed revenue series with ``elecprice_marketprice_wh`` because the
+provider was missing from ``MARKET_PRICE_FEED_IN_TARIFF_PROVIDERS``. External
+EMS bridges push the resolved END-CUSTOMER import price into elecprice, so the
+GA then saw feed-in == import price in every slot — a world where battery
+arbitrage can never pay — and correctly converged to never cycling the battery.
+"""
+
+from akkudoktoreos.optimization.genetic.geneticparams import (
+    MARKET_PRICE_FEED_IN_TARIFF_PROVIDERS,
+)
+
+
+def test_feedintariff_import_counts_as_market_price_provider():
+    assert "FeedInTariffImport" in MARKET_PRICE_FEED_IN_TARIFF_PROVIDERS
+
+
+def test_native_market_providers_still_present():
+    for provider in ("FeedInTariffAkkudoktor", "FeedInTariffEnergyCharts", "FeedInTariffTibber"):
+        assert provider in MARKET_PRICE_FEED_IN_TARIFF_PROVIDERS

--- a/tests/test_overnight_reserve.py
+++ b/tests/test_overnight_reserve.py
@@ -59,7 +59,9 @@ def test_price_aware_release_is_per_slot(monkeypatch):
     np.testing.assert_allclose(reserve, [6000.0, 8800.0, 0.0, 0.0])
 
 
-def _make_inverter(battery: Battery, max_power_wh: float = 10000.0) -> Inverter:
+def _make_inverter(
+    battery: Battery, max_power_wh: float = 10000.0, slot_duration_h: float = 1.0
+) -> Inverter:
     with patch(
         "akkudoktoreos.devices.genetic.inverter.get_eos_load_interpolator",
     ) as interpolator:
@@ -73,6 +75,7 @@ def _make_inverter(battery: Battery, max_power_wh: float = 10000.0) -> Inverter:
                 ac_to_dc_efficiency=1.0,
             ),
             battery=battery,
+            slot_duration_h=slot_duration_h,
         )
 
 
@@ -117,6 +120,41 @@ def test_zero_reserve_keeps_full_export():
         export_reserve_ac_wh=0.0,
     )
     assert grid_export == pytest.approx(10000.0)
+
+
+def test_reserve_caps_soc_pool_not_slot_power_budget():
+    """A reserve larger than one slot's power budget must not zero out export.
+
+    43 kWh pack at 100%, 4.5 kWh discharge budget per 15-min slot, 9 kWh
+    reserve: the pool above min_soc + reserve is ~29 kWh, so the slot still
+    exports its full power budget. Regression: subtracting the reserve from
+    the power-capped per-slot energy gave max(4500 − 9000, 0) = 0 for EVERY
+    slot — export was impossible whenever the night reserve exceeded a single
+    slot's budget, which silently disabled direct marketing altogether.
+    """
+    battery = Battery(
+        SolarPanelBatteryParameters(
+            device_id="battery",
+            capacity_wh=43000,
+            charging_efficiency=1.0,
+            discharging_efficiency=1.0,
+            max_charge_power_w=18000,
+            initial_soc_percentage=100,
+            min_soc_percentage=5,
+        ),
+        prediction_hours=1,
+        slot_duration_h=0.25,
+    )
+    battery.set_discharge_per_hour(np.array([1]))
+    inverter = _make_inverter(battery, max_power_wh=24000.0, slot_duration_h=0.25)
+    grid_export, _grid_import, _losses, _self_consumption = inverter.process_energy(
+        generation=0.0,
+        consumption=0.0,
+        hour=0,
+        allow_battery_grid_export=True,
+        export_reserve_ac_wh=9000.0,
+    )
+    assert grid_export == pytest.approx(4500.0)
 
 
 def test_reserve_does_not_limit_self_consumption():

--- a/tests/test_overnight_reserve.py
+++ b/tests/test_overnight_reserve.py
@@ -1,0 +1,134 @@
+"""Tests for the direct-marketing overnight reserve (export cap).
+
+The reserve keeps tonight's forecast household net-load (load − PV until the
+next morning) in the battery: battery-to-grid export (direct marketing) may not
+sell it, while self-consumption keeps full access. The optional price-aware
+mode releases a slot's reserve down to a safety floor when that slot's own
+export revenue clearly beats the avoided night-import price.
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from akkudoktoreos.devices.genetic.battery import Battery
+from akkudoktoreos.devices.genetic.inverter import Inverter, InverterParameters
+from akkudoktoreos.optimization.genetic import genetic as genetic_module
+from akkudoktoreos.optimization.genetic.genetic import _compute_overnight_reserve
+from akkudoktoreos.optimization.genetic.geneticdevices import (
+    SolarPanelBatteryParameters,
+)
+
+
+def test_energy_balance_reserve_walks_backwards_to_next_morning():
+    """Each slot reserves margin × Σ night net-load until PV next covers load."""
+    load = np.array([100.0, 200.0, 300.0, 50.0])
+    pv = np.array([0.0, 0.0, 0.0, 500.0])  # slot 3 = morning (PV >= load)
+    reserve = _compute_overnight_reserve(load, pv, 0, 4, margin=1.1)
+    np.testing.assert_allclose(reserve, [550.0, 330.0, 0.0, 0.0])
+
+
+def test_reserve_disabled_returns_zeros(monkeypatch):
+    monkeypatch.setattr(genetic_module, "_OVERNIGHT_RESERVE_ENABLED", False)
+    load = np.array([100.0, 200.0, 300.0, 50.0])
+    pv = np.zeros(4)
+    reserve = _compute_overnight_reserve(load, pv, 0, 4, margin=1.1)
+    np.testing.assert_allclose(reserve, np.zeros(4))
+
+
+def test_price_aware_release_is_per_slot(monkeypatch):
+    """Only slots whose OWN revenue clears avoided_import × (1 + margin) release."""
+    monkeypatch.setattr(genetic_module, "_RESERVE_PRICE_AWARE_ENABLED", True)
+    monkeypatch.setattr(genetic_module, "_RESERVE_RELEASE_MARGIN", 0.20)
+    monkeypatch.setattr(genetic_module, "_RESERVE_RELEASE_SPREAD", 0.0)
+    monkeypatch.setattr(genetic_module, "_RESERVE_SAFETY_FRACTION", 0.5)
+    monkeypatch.setattr(genetic_module, "_RESERVE_MIN_SAFETY_FLOOR_WH", 2000.0)
+    monkeypatch.setattr(genetic_module, "_RESERVE_MIN_SAFETY_CAP_WH", 6000.0)
+
+    load = np.array([0.0, 8000.0, 8000.0, 100.0])
+    pv = np.array([0.0, 0.0, 0.0, 200.0])  # slot 3 = morning
+    price = np.full(4, 0.00027)  # 27 ct/kWh import → threshold 32.4 ct/kWh
+    revenue = np.array([0.0004, 0.0002, 0.0002, 0.0002])  # only slot 0 clears it
+
+    reserve = _compute_overnight_reserve(
+        load, pv, 0, 4, margin=1.1, price_array=price, revenue_array=revenue
+    )
+    # Slot 0 (40 ct/kWh > 32.4): released to clamp(17600×0.5, 2000, 6000) = 6000.
+    # Slot 1 (20 ct/kWh): holds the full energy-balance reserve 8800.
+    np.testing.assert_allclose(reserve, [6000.0, 8800.0, 0.0, 0.0])
+
+
+def _make_inverter(battery: Battery, max_power_wh: float = 10000.0) -> Inverter:
+    with patch(
+        "akkudoktoreos.devices.genetic.inverter.get_eos_load_interpolator",
+    ) as interpolator:
+        interpolator.return_value.calculate_expected_direct_consumption.side_effect = min
+        return Inverter(
+            InverterParameters(
+                device_id="inverter",
+                max_power_wh=max_power_wh,
+                battery_id="battery",
+                dc_to_ac_efficiency=1.0,
+                ac_to_dc_efficiency=1.0,
+            ),
+            battery=battery,
+        )
+
+
+def _make_battery() -> Battery:
+    battery = Battery(
+        SolarPanelBatteryParameters(
+            device_id="battery",
+            capacity_wh=10000,
+            charging_efficiency=1.0,
+            discharging_efficiency=1.0,
+            max_charge_power_w=10000,
+            initial_soc_percentage=100,
+            min_soc_percentage=0,
+        ),
+        prediction_hours=1,
+        slot_duration_h=1.0,
+    )
+    battery.set_discharge_per_hour(np.array([1]))
+    return battery
+
+
+def test_reserve_caps_battery_grid_export():
+    inverter = _make_inverter(_make_battery())
+    grid_export, grid_import, _losses, _self_consumption = inverter.process_energy(
+        generation=0.0,
+        consumption=0.0,
+        hour=0,
+        allow_battery_grid_export=True,
+        export_reserve_ac_wh=3000.0,
+    )
+    assert grid_export == pytest.approx(7000.0)
+    assert grid_import == pytest.approx(0.0)
+
+
+def test_zero_reserve_keeps_full_export():
+    inverter = _make_inverter(_make_battery())
+    grid_export, _grid_import, _losses, _self_consumption = inverter.process_energy(
+        generation=0.0,
+        consumption=0.0,
+        hour=0,
+        allow_battery_grid_export=True,
+        export_reserve_ac_wh=0.0,
+    )
+    assert grid_export == pytest.approx(10000.0)
+
+
+def test_reserve_does_not_limit_self_consumption():
+    """Covering the slot's own load may always use the reserved energy."""
+    inverter = _make_inverter(_make_battery())
+    grid_export, grid_import, _losses, self_consumption = inverter.process_energy(
+        generation=0.0,
+        consumption=2000.0,
+        hour=0,
+        allow_battery_grid_export=True,
+        export_reserve_ac_wh=999999.0,
+    )
+    assert grid_import == pytest.approx(0.0)
+    assert self_consumption == pytest.approx(2000.0)
+    assert grid_export == pytest.approx(0.0)


### PR DESCRIPTION
Two additions from our production fork (running on a 43 kWh Victron system), rebased onto this branch:

## 1. `fix(server)`: /v1/prediction/import 400 on DataFrame bodies

A PUT body that pydantic validates as `PydanticDateTimeDataFrame` reached `json.dumps(data)`, which cannot serialize BaseModel instances — every such import failed with HTTP 400 *"Object of type PydanticDateTimeDataFrame is not JSON serializable"* (reproduced on this branch yesterday). One-liner: serialize models via `model_dump_json()`, keep `json.dumps` for plain dicts.

## 2. `feat(optimization)`: overnight reserve for direct marketing

Without a reserve, `battery_grid_export` sells the pack into the evening prices and re-imports the whole night's household load at the (usually higher) import price. We measured this yesterday by replaying our production inputs against this branch: the remaining battery was sold at 18.9 ct/kWh in the first evening slot while the night re-import cost 26.9 ct/kWh.

The reserve is a per-slot **export cap** (never a self-consumption limit): `margin × Σ max(load − PV, 0)` from each slot until PV next covers load, walked backwards. The pack rides the night on self-consumption and arrives near the floor as morning PV takes over.

**Price-aware release** (opt-in, `EOS_RESERVE_PRICE_AWARE=1`): a slot's reserve is released down to a load-adaptive safety floor when that slot's *own* export revenue beats the highest avoided night-import price of its night window by a relative margin (default 20%). Genuine price peaks still get sold; sub-threshold slots can't nibble the reserve away. Per-slot (not window-peak) on purpose — we shipped the window-peak variant first and watched it drain the reserve through sub-threshold neighbour slots.

Implementation notes:
- Pure function of the forecast arrays, computed once per `prepare()` → deterministic, plays nice with your fitness cache.
- Env-gated with behavior-preserving default for the price-aware part; the energy-balance reserve defaults ON (that default is the bugfix — happy to flip it or lift everything into `feedintariff`/`optimization` config fields if you prefer).
- 6 unit tests (`tests/test_overnight_reserve.py`); adjacent suites (inverter, genetic simulation, seeding, 15-min interval) stay green. The 4 `test_geneticoptimize` reference tests fail identically with and without this change (time-of-day dependent "Start hour not synced").

Running in production in our fork since 2026-06-18 (price-aware since 2026-06-29) — the two-pool behavior (free surplus sales + protected night reserve) is what our direct-marketing setup depends on.
