### PR TITLE
fix(test): flaky test_datetimutil test case TC026

### DIFF
--- a/tests/test_datetimeutil.py
+++ b/tests/test_datetimeutil.py
@@ -1204,7 +1204,11 @@ def test_to_datetime(
         # print(f"Result:   {result} tz={result.timezone}")
         # print(f"Compare:  {compare}")
         if expected_approximately:
-            assert compare.time_diff < 300
+            # Compare using Unix timestamps to avoid pendulum timezone state
+            # issues and to prevent staleness from parametrize collection time.
+            import time
+
+            assert abs(result.timestamp() - time.time()) < 300
         else:
             assert compare.equal == True
 


### PR DESCRIPTION
This fix was taken from https://github.com/arneman/EOS/tree/refactor/economic-objective.

Kudos to @arneman.

Avoid flaky TC026 by comparing timestamps at assertion time.