### PR TITLE
fix: use tolist() on numpy arrays in genetic parameter preparation

### DIFF
--- a/src/akkudoktoreos/optimization/genetic/geneticparams.py
+++ b/src/akkudoktoreos/optimization/genetic/geneticparams.py
@@ -281,7 +281,7 @@ class GeneticOptimizationParameters(
                     interval=interval,
                     fill_method="linear",
                 )
-                pvforecast_ac_power = (array * power_to_energy_per_interval_factor).to_list()
+                pvforecast_ac_power = (array * power_to_energy_per_interval_factor).tolist()
             except:
                 logger.info(
                     "No PV forecast data available - defaulting to demo data. Parameter preparation attempt {}.",
@@ -335,7 +335,7 @@ class GeneticOptimizationParameters(
                     interval=interval,
                     fill_method="ffill",
                 )
-                elecprice_marketprice_wh = array.to_list()
+                elecprice_marketprice_wh = array.tolist()
             except:
                 logger.info(
                     "No Electricity Marketprice forecast data available - defaulting to demo data. Parameter preparation attempt {}.",
@@ -352,7 +352,7 @@ class GeneticOptimizationParameters(
                     interval=interval,
                     fill_method="ffill",
                 )
-                loadforecast_power_w = array.to_list()
+                loadforecast_power_w = array.tolist()
             except:
                 logger.info(
                     "No Load forecast data available - defaulting to demo data. Parameter preparation attempt {}.",
@@ -378,7 +378,7 @@ class GeneticOptimizationParameters(
                     interval=interval,
                     fill_method="ffill",
                 )
-                feed_in_tariff_wh = array.to_list()
+                feed_in_tariff_wh = array.tolist()
             except:
                 logger.info(
                     "No feed in tariff forecast data available - defaulting to demo data. Parameter preparation attempt {}.",
@@ -406,7 +406,7 @@ class GeneticOptimizationParameters(
                     interval=interval,
                     fill_method="ffill",
                 )
-                weather_temp_air = array.to_list()
+                weather_temp_air = array.tolist()
             except:
                 logger.info(
                     "No weather forecast data available - defaulting to demo data. Parameter preparation attempt {}.",


### PR DESCRIPTION
Fixes #1166.

`GeneticOptimizationParameters.prepare()` called `.to_list()` on the numpy arrays returned by `prediction.key_to_array()` (5 places). Numpy arrays only provide `.tolist()`, so every automatic energy management run raised `AttributeError`, which the bare `except:` swallowed and reported as the misleading "No ... data available" message before canceling the run (regression from #1155).

## Changes

- Replace the five `.to_list()` calls with `.tolist()` in `src/akkudoktoreos/optimization/genetic/geneticparams.py`.

## Verification

- `pytest tests/test_geneticoptimize.py`: 4 passed, 1 skipped
- pre-commit (isort, ruff, ruff-format, mypy): passed
- Verified on a live Home Assistant add-on installation: with this change the hourly EMS run completes and `/v1/energy-management/plan` returns a plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGkbUKjgbeSCTYrS1dmwwe
