### PR TITLE
fix: fill prediction horizon in FeedInTariffFixed

### DIFF
--- a/src/akkudoktoreos/prediction/feedintarifffixed.py
+++ b/src/akkudoktoreos/prediction/feedintarifffixed.py
@@ -7,7 +7,6 @@ from pydantic import Field
 
 from akkudoktoreos.config.configabc import SettingsBaseModel
 from akkudoktoreos.prediction.feedintariffabc import FeedInTariffProvider
-from akkudoktoreos.utils.datetimeutil import to_datetime
 
 
 class FeedInTariffFixedCommonSettings(SettingsBaseModel):
@@ -35,16 +34,35 @@ class FeedInTariffFixed(FeedInTariffProvider):
         return "FeedInTariffFixed"
 
     async def _update_data(self, force_update: Optional[bool] = False) -> None:
+        """Update feed in tariff data with the fixed tariff.
+
+        Fills the whole prediction horizon on the optimization interval grid,
+        analogous to ElecPriceFixed. Writing only a single value at the current
+        time would leave the `feed_in_tariff_wh` series without coverage of the
+        parameter window used by the optimization.
+        """
         error_msg = "Feed in tariff not provided"
         try:
             feed_in_tariff = (
                 self.config.feedintariff.provider_settings.FeedInTariffFixed.feed_in_tariff_kwh
             )
-        except:
+        except Exception:
             logger.exception(error_msg)
             raise ValueError(error_msg)
         if feed_in_tariff is None:
             logger.error(error_msg)
             raise ValueError(error_msg)
         feed_in_tariff_wh = feed_in_tariff / 1000
-        await self.update_value(to_datetime(), "feed_in_tariff_wh", feed_in_tariff_wh)
+
+        start_datetime = self.ems_start_datetime
+        interval_seconds = self.config.optimization.interval
+        total_hours = self.config.prediction.hours
+        steps = int(total_hours * 3600 // interval_seconds)
+
+        logger.debug(
+            f"Generating fixed feed in tariff for {total_hours} hours starting at {start_datetime}"
+        )
+
+        for idx in range(steps):
+            current_dt = start_datetime.add(seconds=idx * interval_seconds)
+            await self.update_value(current_dt, "feed_in_tariff_wh", feed_in_tariff_wh)

--- a/tests/test_feedintarifffixed.py
+++ b/tests/test_feedintarifffixed.py
@@ -60,3 +60,27 @@ def test_invalid_provider(provider, config_eos):
 # ------------------------------------------------
 # Fixed feed in tariv values
 # ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_data_fills_prediction_horizon(provider, config_eos):
+    """Test that the fixed tariff fills the whole prediction horizon."""
+    ems_eos = get_ems()
+    start_dt = to_datetime("2024-01-01 00:00:00", in_timezone="Europe/Berlin")
+    ems_eos.set_start_datetime(start_dt)
+
+    config_eos.optimization.interval = 3600
+    config_eos.prediction.hours = 24
+
+    await provider.update_data(force_enable=True, force_update=True)
+
+    # One record per optimization interval over the whole horizon
+    assert len(provider) == 24
+
+    records = provider.records
+    for i, record in enumerate(records):
+        # Constant tariff (0.078 kWh = 0.000078 Wh) on interval boundaries
+        assert abs(record.feed_in_tariff_wh - 0.000078) < 1e-9
+        assert record.date_time.minute == 0
+        assert record.date_time.second == 0
+        assert compare_datetimes(record.date_time, start_dt.add(hours=i)).equal


### PR DESCRIPTION
Fixes #1167.

`FeedInTariffFixed._update_data()` wrote exactly one value at the current time on every update, so the `feed_in_tariff_wh` series never covered the prediction horizon and parameter preparation could not use it.

## Changes

- Generate one entry per optimization interval over `prediction.hours` starting at `ems_start_datetime`, analogous to `ElecPriceFixed`.
- Replace the bare `except:` with `except Exception:` (cf. #1159).
- Add regression test `test_update_data_fills_prediction_horizon`.

## Verification

- `pytest tests/test_feedintarifffixed.py`: 3 passed (new test included)
- pre-commit (isort, ruff, ruff-format, mypy): passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGkbUKjgbeSCTYrS1dmwwe
