### PR TITLE
fix PVLib mountingplace None handling

### DIFF
--- a/src/akkudoktoreos/prediction/pvforecastpvlib.py
+++ b/src/akkudoktoreos/prediction/pvforecastpvlib.py
@@ -343,7 +343,7 @@ class PVForecastPVLib(PredictionMixin, PVForecastProvider):
             if plane.strings_per_inverter is None:
                 raise ValueError(f"Plane {plane_idx}: strings_per_inverter must be configured.")
 
-            mountingplace = plane.mountingplace.lower()
+            mountingplace = plane.mountingplace.lower() if plane.mountingplace is not None else None
             if mountingplace == "building":
                 temp_params = TEMPERATURE_MODEL_PARAMETERS["sapm"]["close_mount_glass_glass"]
             elif mountingplace == "free" or mountingplace is None:


### PR DESCRIPTION
## What changed

Handle an explicit `None` value for `pvforecast.planes[].mountingplace` before calling `.lower()`.

## Root cause

`mountingplace` is optional, but the PVLib provider previously executed:

```python
mountingplace = plane.mountingplace.lower()
```

This raised `AttributeError: 'NoneType' object has no attribute 'lower'` for valid configurations containing `"mountingplace": null`.

The existing branch logic already treats `None` the same as `"free"`, selecting the open-rack temperature model. This change simply makes that intended fallback reachable.

## Impact

Existing configurations with an explicit null mounting place no longer crash PVLib forecast calculation.

## Validation

Verified the branch is based on current `main` and contains exactly one source-line change. A local test run was not possible in this environment because the repository could not be cloned from GitHub; CI should provide the full validation.