### PR TITLE
fix(server): /v1/prediction/import rejects every pydantic-validated body

### DIFF
--- a/src/akkudoktoreos/server/eos.py
+++ b/src/akkudoktoreos/server/eos.py
@@ -993,7 +993,7 @@ def fastapi_prediction_import_provider(
     if not provider.enabled() and not force_enable:
         raise HTTPException(status_code=404, detail=f"Provider '{provider_id}' not enabled.")
     try:
-        provider.import_from_json(json_str=json.dumps(data))
+        provider.import_from_json(json_str=data.model_dump_json() if hasattr(data, "model_dump_json") else json.dumps(data))
         provider.update_datetime = to_datetime(in_timezone=get_config().general.timezone)
     except Exception as e:
         raise HTTPException(


### PR DESCRIPTION
`fastapi_prediction_import_provider` accepts `Union[PydanticDateTimeDataFrame, PydanticDateTimeData, dict]` and then calls `json.dumps(data)`.

When FastAPI validates the body into either model — which it does for any well-formed DataFrame payload — `json.dumps` raises `Object of type PydanticDateTimeDataFrame is not JSON serializable`, and the import fails with HTTP 400. Only bodies that fall through to `dict` survive.

Serialize models via `model_dump_json()`, keep `json.dumps` for plain dicts. One line.

Still reproducible on `feat/direct-marketing-battery-grid-export` at `57d2917` (`src/akkudoktoreos/server/eos.py:996`).

Split out of #1157, which bundled it with unrelated work.