### PR TITLE
fix(optimization): direct marketing discards the imported feed-in revenue series

### DIFF
--- a/src/akkudoktoreos/optimization/genetic/geneticparams.py
+++ b/src/akkudoktoreos/optimization/genetic/geneticparams.py
@@ -30,7 +30,19 @@ from akkudoktoreos.optimization.genetic.geneticdevices import (
 from akkudoktoreos.utils.datetimeutil import to_duration
 
 MARKET_PRICE_FEED_IN_TARIFF_PROVIDERS = frozenset(
-    {"FeedInTariffAkkudoktor", "FeedInTariffEnergyCharts", "FeedInTariffTibber"}
+    {
+        "FeedInTariffAkkudoktor",
+        "FeedInTariffEnergyCharts",
+        "FeedInTariffTibber",
+        # FeedInTariffImport carries operator-pushed market revenues (external
+        # EMS bridges import the resolved per-slot feed-in here). Without it,
+        # direct marketing silently replaced the imported revenue series with
+        # elecprice_marketprice_wh — for bridges that push the resolved
+        # END-CUSTOMER import price there, the GA then saw feed-in == import
+        # price in every slot, a world where battery arbitrage can never pay,
+        # and correctly converged to never cycling the battery.
+        "FeedInTariffImport",
+    }
 )
 
 # Do not import directly from akkudoktoreos.core.coreabc
@@ -418,6 +430,14 @@ class GeneticOptimizationParameters(
                             fill_method="ffill",
                         ).tolist()
                     except:
+                        # Loud fallback: substituting the electricity price for
+                        # the feed-in revenue changes the optimization economics
+                        # fundamentally — never do it silently.
+                        logger.warning(
+                            "Direct marketing: no feed_in_tariff_wh data from provider {} - "
+                            "falling back to elecprice_marketprice_wh as feed-in revenue.",
+                            cls.config.feedintariff.provider,
+                        )
                         feed_in_tariff_wh = list(elecprice_marketprice_wh)
                 else:
                     feed_in_tariff_wh = list(elecprice_marketprice_wh)

--- a/tests/test_geneticparams_feedin.py
+++ b/tests/test_geneticparams_feedin.py
@@ -1,0 +1,23 @@
+"""Direct marketing must use the IMPORTED feed-in revenue series.
+
+Regression: with ``feedintariff.provider = FeedInTariffImport`` and direct
+marketing enabled, ``prepare_optimization_parameters`` silently replaced the
+operator-pushed revenue series with ``elecprice_marketprice_wh`` because the
+provider was missing from ``MARKET_PRICE_FEED_IN_TARIFF_PROVIDERS``. External
+EMS bridges push the resolved END-CUSTOMER import price into elecprice, so the
+GA then saw feed-in == import price in every slot — a world where battery
+arbitrage can never pay — and correctly converged to never cycling the battery.
+"""
+
+from akkudoktoreos.optimization.genetic.geneticparams import (
+    MARKET_PRICE_FEED_IN_TARIFF_PROVIDERS,
+)
+
+
+def test_feedintariff_import_counts_as_market_price_provider():
+    assert "FeedInTariffImport" in MARKET_PRICE_FEED_IN_TARIFF_PROVIDERS
+
+
+def test_native_market_providers_still_present():
+    for provider in ("FeedInTariffAkkudoktor", "FeedInTariffEnergyCharts", "FeedInTariffTibber"):
+        assert provider in MARKET_PRICE_FEED_IN_TARIFF_PROVIDERS


### PR DESCRIPTION
With `direct_marketing_enabled` and a feed-in provider outside `MARKET_PRICE_FEED_IN_TARIFF_PROVIDERS`, `prepare()` replaces the feed-in series with `elecprice_marketprice_wh`. `FeedInTariffImport` is not on that list, so any bridge importing its own per-slot revenues loses them the moment direct marketing is switched on.

**The substitute is not a market price.** By EOS's own construction `elecprice_marketprice_wh` is the *gross retail* price — `_price_with_charges()` in `elecpriceenergycharts.py` says so literally ("Build the gross retail price from a net market price"), and `elecpriceakkudoktor.py` adds `charges_wh` the same way. The fallback therefore assigns grid fees, levies and VAT as feed-in revenue. The net market price is no longer present in that array, so the fallback cannot recover it. This affects `FeedInTariffFixed` and `FeedInTariffSmard` as well.

**Measured** on one real production day (48 h, 77 kWh pack, PV 328 kWh, load 98 kWh, 400 generations x 300 individuals, two RNG seeds with 0.00 € spread). Both plans re-priced at the true tariffs afterwards:

| | balance | purchased | sold | exported at negative prices |
|---|---|---|---|---|
| imported series kept | **-36.77 €** | 0.00 € | 36.77 € | **0 Wh** |
| series discarded | **-17.38 €** | 10.56 € | 27.94 € | **104 126 Wh** |

A 19.39 € swing on a single day. The degraded plan buys 39 kWh it does not need, because import and export price look identical, and it exports 104 kWh during negative-price hours — a flat substitute has no negative hours, so the optimizer stops seeing them. It also reports -66.16 €, roughly double the real result, and plans against that.

This PR adds `FeedInTariffImport` to the set, on the reasoning that an imported series is a deliberate statement of actual revenues — under direct marketing especially. It also makes the remaining fallback log a warning instead of substituting silently.

The deeper question — whether that fallback should use a *net* market price at all — is yours to decide. Happy to follow up separately.

Split out of #1157, which bundled it with unrelated work.

<sub>Note: `tests/test_geneticoptimize.py` has 4 failures on this branch (`Start hour not synced. EMS 9 vs. GENETIC 10`). They reproduce identically on unmodified `57d2917` — the test pins `start_hour` to 10 while the EMS start comes from the wall clock. Unrelated to this change.</sub>