### PR TITLE
docs: use uv for development setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,14 +58,14 @@ Our code style checks use [`pre-commit`](https://pre-commit.com).
 To run formatting automatically before every commit:
 
 ```bash
-pre-commit install
-pre-commit install --hook-type commit-msg --hook-type pre-push
+uv run pre-commit install
+uv run pre-commit install --hook-type commit-msg --hook-type pre-push
 ```
 
 Or run them manually:
 
 ```bash
-pre-commit run --all-files
+uv run pre-commit run --all-files
 ```
 
 ### Tests
@@ -73,7 +73,7 @@ pre-commit run --all-files
 Use `pytest` to run tests locally:
 
 ```bash
-python -m pytest -vs --cov src --cov-report term-missing tests/
+uv run python -m pytest -vs --cov src --cov-report term-missing tests/
 ```
 
 ### Commit message style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,13 +27,10 @@ message style checks.
 
 ### Setup development environment
 
-Setup virtual environment, then activate virtual environment and install development dependencies.
+Use `uv` to create the virtual environment and install development dependencies.
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -r requirements-dev.txt
-pip install -e .
+uv sync --extra dev
 ```
 
 Install make to get access to helpful shortcuts (documentation generation, manual formatting, etc.).
@@ -89,7 +86,3 @@ You may use [`commitizen`](https://commitizen-tools.github.io/commitizen) also t
 commit message and commit your change.
 
 ## Thank you!
-
-And last but not least thanks to all our contributors
-
-[![Contributors](https://contrib.rocks/image?repo=Akkudoktor-EOS/EOS)](https://github.com/Akkudoktor-EOS/EOS/graphs/contributors)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,3 +86,7 @@ You may use [`commitizen`](https://commitizen-tools.github.io/commitizen) also t
 commit message and commit your change.
 
 ## Thank you!
+
+And last but not least thanks to all our contributors
+
+[![Contributors](https://contrib.rocks/image?repo=Akkudoktor-EOS/EOS)](https://github.com/Akkudoktor-EOS/EOS/graphs/contributors)


### PR DESCRIPTION
Supersedes #1170 because the original PR branch lives in a contributor fork that the connected GitHub integration cannot modify directly.

This applies the outstanding review feedback from #1170 by updating `CONTRIBUTING.md` to use the repository's current development setup command:

```bash
uv sync --extra dev
```

This matches the existing installation and development documentation and removes the obsolete manual venv/pip setup.