### PR TITLE
test: clean up git and artifact warnings

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,7 +35,9 @@ jobs:
           uv run pytest --finalize --check-config-side-effect -vs --cov src --cov-report term-missing
 
       - name: Upload test artifacts
+        if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: optimize-results
-          path: tests/testdata/new_optimize_result*
+          path: tests/testdata/**/new_optimize_result*
+          if-no-files-found: ignore

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -339,7 +339,7 @@ def test_bump_dev_version_appends_dev(tmp_path):
 # --- 4️⃣ Full workflow simulation with git ---
 def test_workflow_git(tmp_path):
     # Create git repo
-    subprocess.run(["git", "init"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "init", "--initial-branch=main"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.name", "test"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, check=True)
 


### PR DESCRIPTION
## Summary

- initialize the temporary Git repository in `test_workflow_git` with `--initial-branch=main`
- avoid Git's default-branch advisory in pytest logs without changing global Git configuration or suppressing stderr
- upload generated optimization result artifacts only when the test job fails
- use the actual nested `tests/testdata/**/new_optimize_result*` paths
- ignore the no-files case so unrelated test failures do not produce an artifact warning

## Merge order

This PR should be merged **after #1243**.

The pytest workflow content is aligned with #1243's action/Python upgrades so this follow-up does not reintroduce older versions after that PR lands.

Follow-up to: https://github.com/Akkudoktor-EOS/EOS/pull/1243