### PR TITLE
build(docker): harden container and shrink runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,8 @@ Makefile
 NOTICE
 README.md
 .venv/
+tests/
+docs/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,10 @@ RUN --mount=type=bind,source=scripts/get_version.py,target=${EOS_DIR}/scripts/ge
     && apt-get purge -y --auto-remove \
         gcc g++ gfortran \
         libopenblas-dev liblapack-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    # EOS never needs setuid/setgid binaries. Stripping them keeps the unprivileged
+    # eos user from regaining root after the server drops privileges.
+    && find / -xdev \( -perm -4000 -o -perm -2000 \) -type f -exec chmod a-s {} +
 
 ENTRYPOINT []
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,71 +25,84 @@ ENV EOS_OUTPUT_DIR="${EOS_DATA_DIR}/output"
 ENV EOS_CONFIG_DIR="${EOS_DATA_DIR}/config"
 ENV MPLCONFIGDIR="${EOS_DATA_DIR}/mplconfigdir"
 
-# Overwrite when starting the container in a production environment
-ENV EOS_SERVER__EOSDASH_SESSKEY=s3cr3t
+# EOS_SERVER__EOSDASH_SESSKEY is deliberately NOT set here.
+# Baking a session signing key into a public image lets anyone forge EOSdash
+# session cookies. Unset means EOSdash generates a random key per container.
+# Set it via the environment only if sessions must survive a restart.
 
 # Set environment variables to reduce threading needs
 ENV OPENBLAS_NUM_THREADS=1
 ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
+
+# pip behaviour (quiet output, no version nag, no in-image wheel cache)
 ENV PIP_PROGRESS_BAR=off
 ENV PIP_NO_COLOR=1
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PIP_ROOT_USER_ACTION=ignore
 
 # Generic environment
 ENV LANG=C.UTF-8
+ENV PYTHONUNBUFFERED=1
 ENV VENV_PATH=/opt/venv
 # - Use .venv for python commands
 ENV PATH="$VENV_PATH/bin:$PATH"
 
 WORKDIR ${EOS_DIR}
 
-# Create eos user and data directories with eos user permissions
-RUN apt-get update && apt-get install -y --no-install-recommends adduser \
-    && adduser --system --group --no-create-home eos \
-    && mkdir -p "${EOS_DATA_DIR}" \
-    && chown -R eos:eos "${EOS_DATA_DIR}" \
+# Create eos user and data directories with eos user permissions.
+# useradd/groupadd ship with the base image, so no apt install is needed here.
+RUN groupadd --system eos \
+    && useradd --system --gid eos --no-create-home --shell /usr/sbin/nologin eos \
     && mkdir -p "${EOS_CACHE_DIR}" "${EOS_OUTPUT_DIR}" "${EOS_CONFIG_DIR}" "${MPLCONFIGDIR}" \
-    && chown -R eos:eos "${EOS_CACHE_DIR}" "${EOS_OUTPUT_DIR}" "${EOS_CONFIG_DIR}" "${MPLCONFIGDIR}"
-
-# Install build dependencies (Debian)
-# - System deps
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3-venv \
-    gcc g++ gfortran \
-    libopenblas-dev liblapack-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && chown -R eos:eos "${EOS_DATA_DIR}"
 
 # - Copy project metadata first (better Docker layer caching)
 COPY pyproject.toml .
 
-# - Create venv
-RUN python3 -m venv ${VENV_PATH}
-
-# - Upgrade pip inside venv
-RUN pip install --upgrade pip setuptools wheel
-
 # Install EOS/ EOSdash
-# - Copy source
+# - Copy source (needed at runtime too: the version is derived from the source tree)
 COPY src/ ./src
 
-# - Create version information
-COPY scripts/get_version.py ./scripts/get_version.py
-RUN python scripts/get_version.py > ./version.txt
-RUN rm ./scripts/get_version.py
-
-RUN echo "Building Akkudoktor-EOS with Python $PYTHON_VERSION"
-
-# - Install akkudoktoreos package in editable form (-e)
-# - pyproject-toml will read the version from version.txt
-RUN pip install --no-cache-dir -e .
+# Build and install in a single layer so the toolchain never reaches the final image.
+# - Runtime BLAS/LAPACK/OpenMP libraries are installed as manual packages and survive
+#   the --auto-remove of the compilers and the -dev headers.
+# - scripts/get_version.py is bind mounted: it is a build-time helper and must not
+#   linger in any layer.
+# - The pip cache is a BuildKit cache mount, so rebuilds are fast without shipping it.
+RUN --mount=type=bind,source=scripts/get_version.py,target=${EOS_DIR}/scripts/get_version.py \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libopenblas0 liblapack3 libgomp1 \
+    && apt-get install -y --no-install-recommends \
+        gcc g++ gfortran \
+        libopenblas-dev liblapack-dev \
+    # python-slim already provides venv; Home Assistant base images do not.
+    && { python3 -m venv "${VENV_PATH}" \
+        || { apt-get install -y --no-install-recommends python3-venv \
+             && python3 -m venv "${VENV_PATH}"; }; } \
+    && pip install --upgrade pip setuptools \
+    # - Create version information, pyproject.toml reads the version from version.txt
+    && python scripts/get_version.py > ./version.txt \
+    # - Install akkudoktoreos package in editable form (-e)
+    && pip install -e . \
+    && apt-get purge -y --auto-remove \
+        gcc g++ gfortran \
+        libopenblas-dev liblapack-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT []
 
 EXPOSE 8504
 EXPOSE 8503
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8503/v1/health').read()"
+
 # Ensure EOS and EOSdash bind to 0.0.0.0
-# EOS is started with root provileges. EOS will drop root proviledges and switch to user eos.
+# EOS is started with root privileges so it can fix ownership of the mounted data
+# directory. EOS drops root privileges and switches to user eos before serving.
 CMD ["python", "-m", "akkudoktoreos.server.eos", "--host", "0.0.0.0", "--run_as_user", "eos"]
 
 # Persistent data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,8 +31,19 @@ services:
     ulimits:
       nproc: 65535
       nofile: 65535
+    # EOS starts as root only to fix ownership of the mounted data directory, then
+    # drops to the unprivileged "eos" user. Keep the root phase as small as possible.
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETUID
+      - SETGID
     security_opt:
-      - seccomp:unconfined
+      # Prevents the unprivileged eos user from regaining root via setuid binaries.
+      - no-new-privileges:true
     restart: unless-stopped
     ports:
       # Configure what ports to expose on host

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,9 @@ services:
       - MKL_NUM_THREADS=1
       - PIP_PROGRESS_BAR=off
       - PIP_NO_COLOR=1
-      - EOS_SERVER__EOSDASH_SESSKEY=s3cr3t
+      # EOSdash session signing key. Left unset on purpose so a random key is
+      # generated per container. Set your own secret only if sessions must
+      # survive a restart - never reuse the well-known "s3cr3t" placeholder.
       - EOS_SERVER__HOST=0.0.0.0
       - EOS_SERVER__PORT=8503
       - EOS_SERVER__EOSDASH_HOST=0.0.0.0

--- a/src/akkudoktoreos/server/server.py
+++ b/src/akkudoktoreos/server/server.py
@@ -320,7 +320,10 @@ def fix_data_directories_permissions(run_as_user: Optional[str] = None) -> None:
             for name in dirs + files:
                 path = os.path.join(root, name)
                 try:
-                    os.chown(path, uid, gid)
+                    # follow_symlinks=False is a security requirement: this runs as root, and a
+                    # symlink planted in the data directory would otherwise let an unprivileged
+                    # user hand themselves ownership of any file on the system.
+                    os.chown(path, uid, gid, follow_symlinks=False)
                 except PermissionError as e:
                     error_msg = f"Permission denied while updating ownership of '{path}' to user '{run_as_user}'"
                     logger.error(error_msg)
@@ -331,14 +334,12 @@ def fix_data_directories_permissions(run_as_user: Optional[str] = None) -> None:
                     logger.error(error_msg)
         # Also fix the base directory itself
         try:
-            os.chown(base_dir, uid, gid)
+            os.chown(base_dir, uid, gid, follow_symlinks=False)
         except PermissionError as e:
-            error_msg = (
-                f"Permission denied while updating ownership of '{path}' to user '{run_as_user}'"
-            )
+            error_msg = f"Permission denied while updating ownership of '{base_dir}' to user '{run_as_user}'"
             logger.error(error_msg)
         except Exception as e:
-            error_msg = f"Updating ownership failed of '{path}' to user '{run_as_user}': {e}"
+            error_msg = f"Updating ownership failed of '{base_dir}' to user '{run_as_user}': {e}"
             logger.error(error_msg)
 
     if error_msg is None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,6 +17,7 @@ from akkudoktoreos.config.configabc import is_home_assistant_addon
 from akkudoktoreos.core.version import __version__
 from akkudoktoreos.server.server import (
     ServerCommonSettings,
+    fix_data_directories_permissions,
     get_default_host,
     get_default_port,
     wait_for_port_free,
@@ -393,3 +394,29 @@ class TestServerWithEnv:
 
         # Assure config got configuration from environment
         assert config_json["server"]["eosdash_port"] == int(self.eos_env["EOS_SERVER__EOSDASH_PORT"])
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Ownership fixes are POSIX only")
+class TestFixDataDirectoriesPermissions:
+    """The ownership fix runs as root before EOS drops privileges."""
+
+    def test_chown_never_follows_symlinks(self, config_eos, monkeypatch, tmp_path):
+        """A symlink in the data directory must not redirect the root chown.
+
+        Following it would hand ownership of an arbitrary file to the unprivileged user.
+        """
+        follow_symlinks_args = []
+
+        def fake_chown(path, uid, gid, *, follow_symlinks=True):
+            follow_symlinks_args.append(follow_symlinks)
+
+        monkeypatch.setattr(os, "chown", fake_chown)
+
+        data_dir = Path(config_eos.general.data_folder_path)
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (data_dir / "escape").symlink_to(tmp_path / "sensitive")
+
+        fix_data_directories_permissions()
+
+        assert follow_symlinks_args, "expected at least one ownership change"
+        assert all(follow is False for follow in follow_symlinks_args)


### PR DESCRIPTION
## Summary

Reworks the container build for size and security, and closes a privilege-escalation issue found while reviewing it. Image drops from **1.79 GB to 1.23 GB**.

## Security

* **Root chown followed symlinks.** `fix_data_directories_permissions()` runs as root before EOS drops privileges and walks `/data` calling `os.chown`, which follows symlinks by default. A planted symlink redirected the ownership change to its target, e.g. handing `/etc/shadow` to the `eos` user. Both calls now pass `follow_symlinks=False`.
* **Removed the baked-in `EOS_SERVER__EOSDASH_SESSKEY=s3cr3t`** from the Dockerfile and `docker-compose.yaml`. A known signing key in a public image lets anyone forge EOSdash session cookies. Unset means a random key per container.
* **Removed `seccomp:unconfined`**, which disabled Docker's default syscall filter. Added `no-new-privileges:true`, `cap_drop: ALL` and only the five caps the root phase needs (`CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID`, `SETGID`).
* **Stripped setuid/setgid bits** from the base image binaries, which would otherwise let the `eos` user regain root after the drop.
* `scripts/get_version.py` is bind mounted instead of copied and `rm`'d — `RUN rm` leaves the file readable in an intermediate layer.

## Bug fix

Two `except` blocks for the base-dir `chown` interpolated `path`, the loop variable of the preceding `os.walk`. If a base dir is empty and its chown fails, `path` is unbound and the handler raises `NameError`. Now use `base_dir`.

## Image size and build

* Build toolchain (`gcc g++ gfortran`, `*-dev`) installed, used and `apt-get purge --auto-remove`'d in one layer; runtime `libopenblas0`, `liblapack3`, `libgomp1` installed manual so they survive.
* `python3-venv` installed only when the base lacks `venv` — saves a redundant Python on `python-slim`, keeps the HA `base-debian:trixie` build working.
* Eight `RUN` layers collapsed to two; pip cache is a BuildKit cache mount.
* Removed `RUN echo "Building ... $PYTHON_VERSION"` — `ARG` is out of scope after `FROM`, so it printed empty and cost a layer.
* Dropped `wheel`; deduplicated `mkdir`/`chown`; added `tests/`, `docs/` and tool caches to `.dockerignore`.
* Added a `HEALTHCHECK` on `/v1/health` using stdlib `urllib` (no `curl` needed).

## Deliberately unchanged

**EOS still starts as root and drops via `--run_as_user eos`.** A static `USER eos` is the stronger default but breaks the documented bind-mount deployment: a container starting as uid 999 cannot chown a host-owned `/data`. Moving to a named volume would remove the root phase entirely, but needs a data migration and its own PR. This PR shrinks the root window instead.

The editable install is kept: the version is hashed from the live source tree at import, so `src/` must exist at runtime.

## Known follow-up

`drop_root_privileges()` calls `pwd.getpwuid(os.geteuid()).pw_name` unguarded, so `docker run --user 1000:1000` crashes with `KeyError` on a uid absent from `/etc/passwd`. Left out to keep this PR scoped; worth its own issue.

## Not done

No multi-stage build — the dual base (`BUILD_FROM` HA Debian vs `python-slim`) makes venv interpreter provenance differ between stages. No separate dependency layer — `version.txt` needs `src/`, and `pyproject.toml` reads the version from `version.txt`.

## Testing

New test `test_chown_never_follows_symlinks` asserts every `os.chown` call passes `follow_symlinks=False`; confirmed it fails when the fix is reverted.

Verified locally on the `python-slim` variant:

| Check | Result |
|---|---|
| Image size | 1.79 GB → 1.23 GB |
| setuid/setgid binaries | 10 → 0 |
| PID 1 after drop | uid 999, `CapEff: 0000000000000000` |
| Default seccomp profile | healthy — `unconfined` was unnecessary |
| `/v1/health`, `HEALTHCHECK` | `alive` / `healthy` |
| `/data/config` writable by `eos` | yes |
| Compilers, `scripts/`, SESSKEY in image | absent |
| `docker compose config` | valid |

Only the new test ran locally; the full suite starts real servers and should run in CI. The Home Assistant add-on build path was not built locally and needs a CI build, since the setuid strip now touches that base too.
