### PR TITLE
fix: infer Energy-Charts coverage from recent source intervals

### DIFF
--- a/src/akkudoktoreos/prediction/elecpriceenergycharts.py
+++ b/src/akkudoktoreos/prediction/elecpriceenergycharts.py
@@ -270,12 +270,22 @@ class ElecPriceEnergyCharts(ElecPriceProvider):
                 elif force_update:
                     # Use default start date in case of forced update
                     needs_update = True
-                elif not self._has_complete_published_horizon(
-                    now=now, resolution_seconds=resolution_seconds
-                ):
-                    # We have enough history, but not every expected source interval.
-                    start_datetime = gross_start_datetime
-                    needs_update = True
+                else:
+                    # The latest source data may have a different resolution than
+                    # the history before ems_start_datetime. Use its final 24 hours
+                    # so older, finer intervals cannot dominate the median, and
+                    # exclude the predicted tail.
+                    source_series = await self.key_to_raw_series(
+                        key="elecprice_marketprice_raw_wh",
+                        start_datetime=to_datetime(self.highest_orig_datetime).subtract(hours=24),
+                        end_datetime=to_datetime(self.highest_orig_datetime).add(seconds=1),
+                    )
+                    source_resolution_seconds = self._resolution_seconds(source_series)
+                    if not self._has_complete_published_horizon(
+                        now=now, resolution_seconds=source_resolution_seconds
+                    ):
+                        start_datetime = gross_start_datetime
+                        needs_update = True
         else:
             needs_update = True
 

--- a/tests/test_elecpriceenergycharts.py
+++ b/tests/test_elecpriceenergycharts.py
@@ -159,6 +159,7 @@ class TestElecPriceEnergyCharts:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("host_timezone", ["UTC", "Europe/Berlin"])
+    @pytest.mark.parametrize("history_interval_minutes", [15, 60])
     @pytest.mark.parametrize(
         ("now", "last_price", "interval_minutes", "needs_update"),
         [
@@ -180,6 +181,7 @@ class TestElecPriceEnergyCharts:
         provider: ElecPriceEnergyCharts,
         set_other_timezone: Callable[[str], str],
         host_timezone: str,
+        history_interval_minutes: int,
         now: str,
         last_price: str,
         interval_minutes: int,
@@ -196,15 +198,34 @@ class TestElecPriceEnergyCharts:
             pd.Timestamp(last_price, tz="Europe/Berlin"), in_timezone="Europe/Berlin"
         )
         get_ems().set_start_datetime(start)
-        raw_index = pd.date_range(
+        history_index = pd.date_range(
             start=start.subtract(days=35),
+            end=start,
+            freq=f"{history_interval_minutes}min",
+            inclusive="left",
+        )
+        source_index = pd.date_range(
+            start=start,
             end=last_original,
             freq=f"{interval_minutes}min",
         )
         await provider.key_from_series(
-            "elecprice_marketprice_raw_wh", pd.Series(0.0001, index=raw_index)
+            "elecprice_marketprice_raw_wh",
+            pd.Series(0.0001, index=history_index.append(source_index)),
         )
         provider.highest_orig_datetime = last_original
+
+        # Predicted values share the raw key but must not determine source coverage.
+        # Use enough slots at a different resolution to dominate an unbounded estimate.
+        predicted_interval_minutes = 60 if interval_minutes == 15 else 15
+        predicted_index = pd.date_range(
+            start=last_original.add(minutes=predicted_interval_minutes),
+            periods=120,
+            freq=f"{predicted_interval_minutes}min",
+        )
+        await provider.key_from_series(
+            "elecprice_marketprice_raw_wh", pd.Series(0.00005, index=predicted_index)
+        )
 
         published_end = start.add(days=1 if fixed_now.hour < 14 else 2)
         response_index = pd.date_range(


### PR DESCRIPTION
## Problem

After #1278, the coverage check still takes its interval size from history before `ems_start_datetime`. When hourly history is followed by quarter-hourly published prices, a final timestamp of 23:00 can incorrectly count as covering through midnight. The reverse transition can cause unnecessary refreshes.

## Changes

- Keep the existing resolution and length check for forecasting history.
- Infer coverage resolution separately from the final 24 hours ending at `highest_orig_datetime`, excluding the predicted tail stored under the same raw key.
- Bound the source sample to 24 hours so older, finer intervals do not dominate the existing median estimator when the latest published day is hourly.
- Expand the existing coverage regression matrix to 44 cases with independently varied history resolution and an opposing-resolution predicted tail. This retains the publication cutoff, UTC/Berlin host timezone, stored-value, and DST assertions.

Follow-up to the review in #1278: https://github.com/Akkudoktor-EOS/EOS/pull/1278#discussion_r3940805727

## Validation

- Expanded coverage tests against unchanged merged #1278 code: 12 failed, 32 passed, reproducing missed and unnecessary refreshes.
- Final coverage tests: **44 passed**, with `--check-config-side-effect`.
- Related provider suites during implementation: 89 passed, 1 skipped, 1 deselected; the 4 remaining failures identified the reverse-transition median issue and all pass in the final 44-case run. The live-API resampling test was deselected. The full related suites were not rerun after the final 24-hour bound adjustment.
- All applicable pre-commit checks passed, including isort, Ruff, formatting, and mypy.

The existing median estimator remains heuristic if resolution changes within the final source-day sample; this change targets differing historical and published-day resolutions.

Implemented and tested with OpenAI Codex.