### PR TITLE
fix: normalize expected configuration paths on macOS

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -167,7 +167,8 @@ def test_get_config_file_path(user_config_dir_patch, config_eos, config_default_
     user_config_dir_patch.return_value = str(config_default_dir_user)
 
     def cfg_file(dir: Path) -> Path:
-        return dir.joinpath(ConfigEOS.CONFIG_FILE_NAME)
+        # Match production directory normalization, including macOS /var aliases.
+        return dir.resolve().joinpath(ConfigEOS.CONFIG_FILE_NAME)
 
     # Config newly created from fixture with fresh user config directory
     assert config_eos._get_config_file_path() == (cfg_file(config_default_dir_user), True)


### PR DESCRIPTION
`test_get_config_file_path` fails on macOS because temporary directories can use `/var/folders/...` while production resolves them to `/private/var/folders/...`.

Normalize the expected directory with `Path.resolve()` in the shared `cfg_file` helper before appending the configuration filename. This covers every path assertion in the test while preserving directory selection, filename checks, and production behavior.

Closes #1274.

Validation:
- Reproduced the failure on macOS before the change; the focused test passes afterward.
- All 184 tests in `test_config.py`, `test_configabc.py`, `test_configfile.py`, and `test_configmigrate.py` pass on macOS with `--finalize --check-config-side-effect`, including on the isolated PR branch.
- Pre-commit hooks for the changed file, including the mypy hook, pass; `git diff --check` passes.
- `make mypy` reports the same 961 existing errors before and after the change, verified with a shadow-file comparison. The typing-environment discrepancy is tracked in #1276.
- Linux tests were not run locally; the repository's Ubuntu CI will provide that verification.

This pull request was created by an LLM.
