### PR TITLE
chore: ignore the artifacts the test suite writes into the work tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,6 +260,12 @@ tests/testdata/new_optimize_result*
 tests/testdata/openapi-new.json
 tests/testdata/openapi-new.md
 tests/testdata/config-new.md
+# Working copies test_configmigrate leaves behind when a migration test fails
+tests/testdata/*.new
+# Written by test_visualize into the working directory
+example_report.pdf
+# Written by test_config into the working directory
+tests/testdata/docs/
 
 # FastHTML session key
 .sesskey


### PR DESCRIPTION
test_configmigrate leaves a <fixture>.new working copy behind whenever a migration test fails, test_visualize writes example_report.pdf into the current directory, and test_config creates tests/testdata/docs/. All three showed up as untracked noise in every status and invited accidental commits.

The PR is part of #1192